### PR TITLE
Fixed permissions for ../logs and ./config directories in install.sh script

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -22,7 +22,7 @@ cp workflow-config.yaml.example ../config/workflow-config.yaml
 
 # Fix permissions so AI MOA can read-write
 chown $USER:$USER ../config/*
-chmod ug+rw ../config -R
+chmod ug+rwx ../config -R
 chown $USER:$USER ../config/*
 chown ug+rwx../logs -R
 # Protect config.yaml from Other users

--- a/src/install.sh
+++ b/src/install.sh
@@ -21,10 +21,10 @@ cp config.yaml.example ../config/config.yaml
 cp workflow-config.yaml.example ../config/workflow-config.yaml
 
 # Fix permissions so AI MOA can read-write
-chown $USER:$USER ../config/*
+chown $USER:$USER ../config -R
 chmod ug+rwx ../config -R
-chown $USER:$USER ../config/*
-chown ug+rwx../logs -R
+chown $USER:$USER ../logs -R
+chmod ug+rwx../logs -R
 # Protect config.yaml from Other users
 chmod o-rw ../config/config.yaml
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -21,8 +21,10 @@ cp config.yaml.example ../config/config.yaml
 cp workflow-config.yaml.example ../config/workflow-config.yaml
 
 # Fix permissions so AI MOA can read-write
+chown $USER:$USER ../config/*
 chmod ug+rw ../config -R
 chown $USER:$USER ../config/*
+chown ug+rwx../logs -R
 # Protect config.yaml from Other users
 chmod o-rw ../config/config.yaml
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -22,9 +22,11 @@ cp workflow-config.yaml.example ../config/workflow-config.yaml
 
 # Fix permissions so AI MOA can read-write
 chown $USER:$USER ../config -R
-chmod ug+rwx ../config -R
+chmod ug+x ../config
+chmod ug+rw ../config/*
 chown $USER:$USER ../logs -R
-chmod ug+rwx../logs -R
+chmod ug+x ../logs
+chmod ug+rw ../logs/*
 # Protect config.yaml from Other users
 chmod o-rw ../config/config.yaml
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -21,12 +21,9 @@ cp config.yaml.example ../config/config.yaml
 cp workflow-config.yaml.example ../config/workflow-config.yaml
 
 # Fix permissions so AI MOA can read-write
-chown $USER:$USER ../config -R
-chmod ug+x ../config
-chmod ug+rw ../config/*
-chown $USER:$USER ../logs -R
-chmod ug+x ../logs
-chmod ug+rw ../logs/*
+chown $USER:$USER ../config ../logs -R
+chmod ug+rwx ../config ../logs
+chmod ug+rw ../config/* ../logs/*
 # Protect config.yaml from Other users
 chmod o-rw ../config/config.yaml
 


### PR DESCRIPTION
Fixed permissions for ../logs and ./config directories in install.sh script

## Summary by Sourcery

Bug Fixes:
- Corrected permissions for the ../logs directory in the install.sh script to ensure proper read-write-execute access.