### PR TITLE
Fixed permissions for install-aimoa.sh and fix-aimoa.sh

### DIFF
--- a/gwc-aimee/fix-aimoa.sh
+++ b/gwc-aimee/fix-aimoa.sh
@@ -18,9 +18,7 @@ AIMOA=$(pwd)
 
 # Modify user:group permissions:
 /bin/chown aimoa:aimoa $AIMOA/* -R
-
 # Fix permissions so AI MOA can read-write
-/bin/chown $USER:$USER $AIMOA/config $AIMOA/logs -R
 /bin/chmod ug+rwx $AIMOA/config $AIMOA/logs
 /bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/*
 # Protect config.yaml from Other users

--- a/gwc-aimee/install-aimoa.sh
+++ b/gwc-aimee/install-aimoa.sh
@@ -98,7 +98,6 @@ pip install -r $AIMOA/src/requirements.txt
 # Modify user:group permissions
 /bin/chown aimoa:aimoa $AIMOA/* -R
 # Fix permissions so AI MOA can read-write
-/bin/chown $USER:$USER $AIMOA/config $AIMOA/logs -R
 /bin/chmod ug+rwx $AIMOA/config $AIMOA/logs
 /bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/*
 # Protect config.yaml from Other users


### PR DESCRIPTION
Fixed permissions for install-aimoa.sh and fix-aimoa.sh

## Summary by Sourcery

Bug Fixes:
- Corrected file permissions in install-aimoa.sh and fix-aimoa.sh by removing redundant chown commands.