### PR TITLE
Updated install-aimoa.sh to create user aimoa with home directory

### DIFF
--- a/gwc-aimee/fix-aimoa.sh
+++ b/gwc-aimee/fix-aimoa.sh
@@ -26,6 +26,8 @@ USERNAME=$(awk -F':' -v uid=1000 '$3 == uid { print $1 }' /etc/passwd)
 # Fix permissions so AI MOA can read-write
 /bin/chmod ug+rwx $AIMOA/config $AIMOA/logs $AIMOA/.env
 /bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/* $AIMOA/.env/*
+/bin/chmod ug+rw $AIMOA/llm-container/models
+/bin/chmod ug+rw $AIMOA/src/*.lock
 # Protect config.yaml from Other users
 /bin/chmod o-rwx $AIMOA/config
 

--- a/gwc-aimee/install-aimoa.sh
+++ b/gwc-aimee/install-aimoa.sh
@@ -96,7 +96,7 @@ source $AIMOA/.env/bin/activate
 pip install -r $AIMOA/src/requirements.txt
 
 # Create Linux user and group for 'aimoa':
-/usr/sbin/adduser aimoa
+/usr/sbin/useradd -m aimoa	# Requires home directory for google-chrome files
 # Add current user to 'aimoa' group
 /usr/sbin/usermod -a -G aimoa $USER
 /usr/sbin/usermod -a -G aimoa $USERNAME
@@ -109,6 +109,7 @@ pip install -r $AIMOA/src/requirements.txt
 # Fix permissions so AI MOA can read-write
 /bin/chmod ug+rwx $AIMOA/config $AIMOA/logs
 /bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/*
+/bin/chmod ug+rw $AIMOA/llm-container/models
 # Protect config.yaml from Other users
 /bin/chmod o-rwx $AIMOA/config
 # Confirm user belongs to group "aimoa"

--- a/src/workflow-config.yaml.example
+++ b/src/workflow-config.yaml.example
@@ -415,7 +415,7 @@ ai_prompts:
     Follow this format strictly and DO NOT add any other text other than JSON object in the response!
 
   get_provider: >
-    For context, some doctors' names may include middle names or middle intials. Based on the above document, select the appropriate provider from the following list containing firstname and lastname that matches the health provider that the document is written to, the referring physician, mentions the doctor's name, or carbon copied to. Remember, favour a doctor provider over a clinic, if no provider matches then select 'oscardoc', and only return the provider number (eg: 20) nothing else.
+    For context, some doctors names may include middle names or middle intials. Based on the above document, select the appropriate provider from the following list containing firstname and lastname that matches the health provider that the document is written to, the referring physician, mentions the doctor name, or carbon copied to. Remember, favour a doctor provider over a clinic, if no provider matches then select 'oscardoc', and only return the provider number (eg: 20) nothing else.
 
   build_sub_prompt: >
     For the following question if confidence level is more than 85% give the answer in one word using the format 'True' else 'False'.


### PR DESCRIPTION
Updated install-aimoa.sh to create user aimoa with home directory (which may be required by browser).

## Summary by Sourcery

Enhancements:
- Modify install-aimoa.sh to create the 'aimoa' user with a home directory, which is necessary for certain applications like Google Chrome.