### PR TITLE
Fixed loading provider_list.yaml

### DIFF
--- a/gwc-aimee/fix-aimoa.sh
+++ b/gwc-aimee/fix-aimoa.sh
@@ -24,10 +24,10 @@ USERNAME=$(awk -F':' -v uid=1000 '$3 == uid { print $1 }' /etc/passwd)
 /bin/chown aimoa:aimoa $AIMOA/* -R
 /bin/chown aimoa:aimoa $AIMOA/.env/* -R -P
 # Fix permissions so AI MOA can read-write
-/bin/chmod ug+rwx $AIMOA/config $AIMOA/logs $AIMOA/.env
-/bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/* $AIMOA/.env/*
+/bin/chmod ug+rwx $AIMOA/config $AIMOA/logs $AIMOA/.env $AIMOA/src/config
+/bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/* $AIMOA/.env/* $AIMOA/src/config/*.yaml
 /bin/chmod ug+rw $AIMOA/llm-container/models
-/bin/chmod ug+rw $AIMOA/src/*.lock
+/bin/chmod ug+rw $AIMOA/src/*.lock $AIMOA/config/*.lock
 # Protect config.yaml from Other users
 /bin/chmod o-rwx $AIMOA/config
 

--- a/gwc-aimee/install-aimoa.sh
+++ b/gwc-aimee/install-aimoa.sh
@@ -63,7 +63,8 @@ AIMOA=$(pwd)
 /bin/cp $AIMOA/config/config.yaml $AIMOA/config/config.yaml.$(date +'%Y-%m-%d')
 /bin/cp $AIMOA/src/workflow-config.yaml $AIMOA/src/workflow-config.yaml.$(date +'%Y-%m-%d')
 /bin/cp $AIMOA/config/workflow-config.yaml $AIMOA/config/workflow-config.yaml.$(date +'%Y-%m-%d')
-/bin/cp $AIMOA/src/provider_list.yaml $AIMOA/src/provider_list.yaml.$(date +'%Y-%m-%d')
+/bin/cp $AIMOA/config/provider_list.yaml $AIMOA/config/provider_list.yaml.$(date +'%Y-%m-%d')
+/bin/cp $AIMOA/src/config/provider_list.yaml $AIMOA/src/config/provider_list.yaml.$(date +'%Y-%m-%d')
 # Create config files in config directory
 /bin/echo "Creating config files from templates..."
 /bin/cp $AIMOA/src/config.yaml.example $AIMOA/config/config.yaml
@@ -74,6 +75,7 @@ AIMOA=$(pwd)
 /bin/echo "Removing provider_list for clean start..."
 /bin/sleep 5s
 /bin/rm $AIMOA/config/provider_list.yaml
+/bin/rm $AIMOA/src/config/provider_list.yaml
 # Missing provider list will cause AI-MOA to regenerate the list
 
 # Confirm your local timezone is set:

--- a/src/config/provider_list_manager.py
+++ b/src/config/provider_list_manager.py
@@ -259,7 +259,7 @@ class ProviderListManager:
             
             provider_list = {'providers': providers}
             try:
-                output_file = self.config.get('provider_list.output_file', 'config/provider_list.yaml')
+                output_file = self.config.get('provider_list.output_file', '../config/provider_list.yaml')
                 self.logger.info("Saving provider details to yaml file.")
                 with open(output_file, 'w') as file:
                     yaml.dump(provider_list, file, default_flow_style=False)

--- a/src/processors/provider_tagger/provider.py
+++ b/src/processors/provider_tagger/provider.py
@@ -48,7 +48,7 @@ def get_provider_list(self):
         >>> print(result)
         (True, 123)  # if a provider ID is successfully extracted
     """
-	file_name = self.config.get('provider_list.output_file', '')
+	file_name = self.config.get('provider_list.output_file', '../config/provider_list.yaml') # Specify location of provider_list.yaml
 
 	provider_list = self.get_provider_list_filemode(self,file_name)
 


### PR DESCRIPTION
Fixed loading provider_list.yaml by specifying location of ../config/provider_list.yaml in provider_list_manager.py and provider.py

## Summary by Sourcery

Fix the loading of 'provider_list.yaml' by specifying the correct file path in relevant scripts and update file permissions to ensure proper access.

Bug Fixes:
- Correct the file path for loading 'provider_list.yaml' in 'provider_list_manager.py' and 'provider.py' to ensure the file is accessed correctly.

Enhancements:
- Update file permissions in 'fix-aimoa.sh' to include the 'src/config' directory and its YAML files, ensuring proper read-write access.