### PR TITLE
Fixed command to add google-chrome repo to sources.list.d/google.list

### DIFF
--- a/gwc-aimee/install-aimoa.sh
+++ b/gwc-aimee/install-aimoa.sh
@@ -136,7 +136,7 @@ pip install -r $AIMOA/src/requirements.txt
 # Add Chrome repository key to keychain
 /bin/wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 # Add Chrome repo to system sources
-/bin/echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+su -c "/bin/echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list"
 apt-get update
 # Install google-chrome-stable
 apt-get -y install google-chrome-stable

--- a/gwc-aimee/install-aimoa.sh
+++ b/gwc-aimee/install-aimoa.sh
@@ -136,7 +136,7 @@ pip install -r $AIMOA/src/requirements.txt
 # Add Chrome repository key to keychain
 /bin/wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 # Add Chrome repo to system sources
-su -c "/bin/echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list"
+/bin/echo "deb http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list.d/google.list
 apt-get update
 # Install google-chrome-stable
 apt-get -y install google-chrome-stable


### PR DESCRIPTION
Fixed command to add google-chrome repo to sources.list.d/google.list

## Summary by Sourcery

Bug Fixes:
- Correct the command to add the Google Chrome repository to the system sources list

## Summary by Sourcery

Bug Fixes:
- Correct the command to add the Google Chrome repository to the system sources list by using 'sudo tee' instead of appending directly.