### PR TITLE
CANCEL Pull Request (Wrong request to branch): Fix Unassigned name, error manager tagging, limit document description, LLM timeout message, reset lock on startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -66,13 +66,18 @@ class AIMOAAutomation:
     Handles the processing of workflows and documents.
     """
 
-    def __init__(self, config_file: str, workflow_config_file: str) -> None:
+    def __init__(self, config_file: str, workflow_config_file: str, reset_lock: bool) -> None:
         """
         Initialize the AIMOAAutomation instance with the provided configuration files.
         """
         self.config: ConfigManager = ConfigManager(config_file, workflow_config_file)
         setup_logging(self.config)
         self.logger: logging.Logger = logger
+
+        if reset_lock and self.config.get('lock.status'):
+            self.config.update_lock_status(False)
+            self.logger.info(f"Lock set to False, --reset-lock was used while starting the application.")
+
         self.session_manager: SessionManager = SessionManager(self.config)
         self.login_manager: LoginManager = LoginManager(self.config)
         self.workflow: Workflow = Workflow(self.config,self.session_manager,self.login_manager)
@@ -132,13 +137,13 @@ class AIMOAAutomation:
         duration: float = (end_time - start_time).total_seconds()
         self.logger.info("Workflow task completed. Duration: %s seconds", duration)
 
-@huey.task(expires=1800, retries=3, retry_delay=10)
-def process_workflow_task(config_file: str, workflow_config_file: str) -> None:
+@huey.task(expires=1, retries=3, retry_delay=10)
+def process_workflow_task(config_file: str, workflow_config_file: str, reset_lock: bool) -> None:
     """
     Process the workflow as a Huey task.
     Task expires after 30 minutes and retries up to 3 times.
     """
-    with AIMOAAutomation(config_file, workflow_config_file) as ai_moa:
+    with AIMOAAutomation(config_file, workflow_config_file, reset_lock) as ai_moa:
         ai_moa.process_workflow()
 
 def args_parse_aimoa():
@@ -161,6 +166,7 @@ def args_parse_aimoa():
     parser.add_argument("--workflow-config", help="Path to the workflow config file")
     parser.add_argument("--cron-interval", help="Cron interval for scheduling tasks (e.g. '*/5' for every 5 minutes)")
     parser.add_argument("--run-immediately", action="store_true", help="Run the task immediately when started")
+    parser.add_argument("--reset-lock", action="store_true", help="Run the task while bypassing the process lock, if set.")
     args = parser.parse_args()
     return args
 
@@ -197,7 +203,7 @@ def schedule_tasks() -> None:
     """
     logger.info("Running scheduled tasks")
     try:
-        process_workflow_task(config_file, workflow_config_file)
+        process_workflow_task(config_file, workflow_config_file, reset_lock)
     except Exception as e:
         logger.exception("Error during scheduled task execution: %s", e)
 
@@ -227,6 +233,7 @@ if __name__ == "__main__":
     # Load configuration files
     config_file = args.config or os.environ.get('AIMOA_CONFIG') or os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config.yaml")
     workflow_config_file = args.workflow_config or os.environ.get('AIMOA_WORKFLOW_CONFIG') or os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "workflow-config.yaml")
+    reset_lock = args.reset_lock    
     
     try:
         check_config_files_exist(config_file, workflow_config_file)
@@ -243,7 +250,7 @@ if __name__ == "__main__":
 
     if run_immediately:
         logger.info("Running task immediately...")
-        process_workflow_task(config_file, workflow_config_file)
+        process_workflow_task(config_file, workflow_config_file, reset_lock)
 
     try:
         logger.info("Starting Huey consumer...")

--- a/src/processors/document_tagger/document_category.py
+++ b/src/processors/document_tagger/document_category.py
@@ -115,6 +115,18 @@ def get_document_description(self):
                 name = 'get_document_description_' + task['name']
                 self.config.set_shared_state(name, previous_response)
 
+            # Check if there is more than one line
+            if previous_response.count('\n') > 0:
+                # Split the response into lines
+                lines = previous_response.split('\n')
+                
+                # Iterate over lines to find the first non-empty line
+                for line in lines:
+                    if line.strip():  # Check if the line is not empty (ignores leading/trailing spaces)
+                        # Update previous_response with the first non-empty line
+                        previous_response = line
+                        break
+
             return True, previous_response
 
     return False

--- a/src/processors/o19/o19_updater.py
+++ b/src/processors/o19/o19_updater.py
@@ -77,6 +77,11 @@ def update_o19(self):
 
 	self.provider_number.append(default_provider_id)
 
+	error_manager = self.config.get_shared_state('error_manager')
+
+	if error_manager:
+		self.provider_number.append(error_manager)
+
 	for category in self.document_categories:
 		if category['name'].lower() == self.fileType:
 			try:

--- a/src/processors/patient_tagger/__init__.py
+++ b/src/processors/patient_tagger/__init__.py
@@ -19,6 +19,6 @@
 # source code can be acquired publicly in its latest most up-to-date version, within one month.
 # ***
 
-from .patient import get_patient_hin, get_patient_dob, get_patient_name, filter_results, get_patient_Html_Common, convert_date, get_patient_Html, unidentified_patients
+from .patient import verify_demographic_number, get_patient_hin, get_patient_dob, get_patient_name, filter_results, get_patient_Html_Common, convert_date, get_patient_Html, unidentified_patients
 
-__all__ = ['get_patient_hin', 'get_patient_dob', 'get_patient_name', 'get_mrp_details', 'filter_results', 'get_patient_Html_Common', 'convert_date', 'get_patient_Html', 'unidentified_patients']
+__all__ = ['verify_demographic_number', 'get_patient_hin', 'get_patient_dob', 'get_patient_name', 'get_mrp_details', 'filter_results', 'get_patient_Html_Common', 'convert_date', 'get_patient_Html', 'unidentified_patients']

--- a/src/processors/provider_tagger/provider.py
+++ b/src/processors/provider_tagger/provider.py
@@ -24,7 +24,7 @@ import yaml
 from config import ProviderListManager
 
 def get_provider_list(self):
-	"""
+    """
     Retrieves a provider ID from the OCR text or defaults to a pre-configured provider ID.
 
     This method processes the provider list from a file specified in the configuration and attempts to 
@@ -48,29 +48,33 @@ def get_provider_list(self):
         >>> print(result)
         (True, 123)  # if a provider ID is successfully extracted
     """
-	file_name = self.config.get('provider_list.output_file', '../config/provider_list.yaml') # Specify location of provider_list.yaml
+    file_name = self.config.get('provider_list.output_file', '../config/provider_list.yaml') # Specify location of provider_list.yaml
 
-	provider_list = self.get_provider_list_filemode(self,file_name)
+    provider_list = self.get_provider_list_filemode(self,file_name)
 
-	default_provider_id = self.default_values.get('default_provider_tagging_id', '')
+    default_provider_id = self.default_values.get('default_provider_tagging_id', '')
 
 
-	if provider_list is None:
-	    #If provider list is empty return default provider id for notifiying
-	    return True, default_provider_id
+    if provider_list is None:
+        #If provider list is empty return default provider id for notifiying
+        return True, default_provider_id
 
-	prompt = self.ai_prompts.get('get_provider', '')
+    prompt = self.ai_prompts.get('get_provider', '')
 
-	prompt = f"\n{self.ocr_text}.\n" + prompt + str(provider_list)
-	text = self.query_prompt(self,prompt)[1]
+    prompt = f"\n{self.ocr_text}.\n" + prompt + str(provider_list)
+    text = self.query_prompt(self,prompt)[1]
 
-	match = re.search(r'\b\d+\b', text)
+    match = re.search(r'\b\d+\b', text)
 
-	if match:
-	    numerical_value = int(match.group())
-	    return True, numerical_value
-	else:
-	    return True,default_provider_id
+    if match:
+        numerical_value = int(match.group())
+        return True, numerical_value
+    else:
+        default_error_manager_id = self.default_values.get('default_error_manager_id', None)
+        if default_error_manager_id:
+            self.config.set_shared_state('error_manager', default_error_manager_id)
+        return True,default_provider_id
+
 
 
 def get_provider_list_filemode(self,file_path):

--- a/src/processors/utils/llm.py
+++ b/src/processors/utils/llm.py
@@ -75,11 +75,13 @@ def query_prompt(self,prompt):
     except Timeout:
         self.config.update_lock_status(False)
         self.logger.info(f"Lock released.")
+        self.logger.info(f"An error occurred waiting for LLM response, exceeded time out. Stopping task processing Document No. {self.file_name}")
         raise SystemExit("Stopping task due to LLM timed out.")
     except RequestException as e:
         self.config.update_lock_status(False)
         self.logger.info(f"Lock released.")
-        raise SystemExit("Stopping task due to LLM timed out.")
+        self.logger.info(f"An error occurred waiting for LLM response, LLM Request Exception. Stopping task processing Document No. {self.file_name}")
+        raise SystemExit("Stopping task due to LLM Request Exception.")
     else:
         if response.status_code != 200:
             return False

--- a/src/processors/workflow/emr_workflow.py
+++ b/src/processors/workflow/emr_workflow.py
@@ -108,6 +108,7 @@ class Workflow:
         self.get_patient_name = patient.get_patient_name
         self.get_mrp_details = patient.get_mrp_details
         self.unidentified_patients = patient.unidentified_patients
+        self.verify_demographic_number = patient.verify_demographic_number
         self.filter_results = patient.filter_results
         self.get_patient_Html_Common = patient.get_patient_Html_Common
         self.convert_date = patient.convert_date

--- a/src/workflow-config.yaml.example
+++ b/src/workflow-config.yaml.example
@@ -35,6 +35,9 @@ default_values:
     2000-01-01
   default_category: >
     Miscellaneous
+  default_error_manager_id:
+    # Sets the id for the default error manager (o19,o15 provider list value), used when the provider or demographic is not identified.
+    999998
 
 # Workflow Configuration
 # Note: Use the view_output function to view the output from the workflow. It can be used to view the document category, document description, provider details, demographic details, and MRP information. The view_output function should be called after the relevant function calls to ensure proper results.
@@ -78,18 +81,27 @@ workflow:
       true_next: filter_results
       false_next: get_patient_name
     - name: filter_results
+      true_next: verify_demographic_number
+      false_next: get_patient_name
+    - name: verify_demographic_number
       true_next: get_mrp_details
       false_next: get_patient_name
     - name: get_patient_name
       true_next: filter_results
       false_next: get_patient_dob
     - name: filter_results
+      true_next: verify_demographic_number
+      false_next: get_patient_dob
+    - name: verify_demographic_number
       true_next: get_mrp_details
       false_next: get_patient_dob
     - name: get_patient_dob
       true_next: filter_results
       false_next: unidentified_patients
     - name: filter_results
+      true_next: verify_demographic_number
+      false_next: unidentified_patients
+    - name: verify_demographic_number
       true_next: get_mrp_details
       false_next: unidentified_patients
     - name: get_mrp_details


### PR DESCRIPTION
- Fix for Unassigned demographic numbers that were higher than actual last demographic number
- Created an error manager id that would be tagged for error files
- Limit document description to a maximum
- Edited LLM timeout error to show Document No.
- Added main.py startup flag that can reset the file lock, so users can restart AI-MOA to continue if there was an inadvertent lock on yaml config files

## Summary by Sourcery

Fix bugs related to unassigned demographic numbers, error manager tagging, document description limits, and LLM timeout messages. Add a startup flag to reset file locks and improve patient search functionality.

Bug Fixes:
- Fixed a bug where unassigned demographic numbers were higher than the actual last demographic number.
- Fixed LLM timeout error to show the document number.
- Fixed document descriptions to limit them to a single line.
- Fixed provider tagging to use a default error manager ID if no provider is found.
- Fixed patient search to allow leading/trailing letters in Health Insurance Number (HIN).
- Fixed patient search to include wildcard search for all patient properties except demographic number

Chores:
- Added a startup flag to reset the file lock on startup so users can restart AI-MOA if there is an inadvertent lock on YAML config files.
- Added error manager ID tagging for error files