### PR TITLE
Update: Default installation script for processing both Pending and IncomingDocs/Fax

### DIFF
--- a/install/Readme.md
+++ b/install/Readme.md
@@ -1,7 +1,7 @@
 # Aimee AI (AI-MOA) #
 *Copyright © 2024 by Spring Health Corporation, Toronto, Ontario, Canada*<br />
 *LICENSE: GNU Affero General Public License Version 3*<br />
-**Document Version 2025.02.02**
+**Document Version 2025.02.18**
 <p align="center">
   <img src="https://getwellclinic.ca/images/GetWellClinic/Logos-Icons/AimeeAI-pc.png" alt="Aimee AI">
 </p>
@@ -409,6 +409,20 @@ To exit/stop watching
 Crtl-C
 ```
 
+**AI-MOA Maintenance cron job**
+
+- AI-MOA may accumulate browser temp files in /tmp directory.
+- Depending on how a user updates or edits config files, misconfigured file permissions may cause unexpected errors when running the program with user prileges.
+
+Consider installing the "aimoa-cron-maintenance.sh" script in sudoer's crontab to run periodically to fix permissions and clear the /tmp directory files accumulated by AI-MOA.
+
+```sudo crontab -e```
+
+Add the following to the crontab file:
+```
+0 6 * * *	/opt/ai-moa/install/aimoa-cron-maintenance.sh
+```
+
 ### Start/Stop LLM Container Manually ###
 
 The AI LLM Container runs separately in docker as llm-container and caddy.
@@ -425,7 +439,7 @@ To stop the LLM Container manually:
 sudo ./stop-llm.sh
 ```
 
-## Troubleshooting ##
+## Troubleshooting and Tips ##
 
 ### Clinic workflow suggestions ###
 

--- a/install/Readme.md
+++ b/install/Readme.md
@@ -414,9 +414,9 @@ Crtl-C
 - AI-MOA may accumulate browser temp files in /tmp directory.
 - Depending on how a user updates or edits config files, misconfigured file permissions may cause unexpected errors when running the program with user prileges.
 
-Consider installing the "aimoa-cron-maintenance.sh" script in sudoer's crontab to run periodically to fix permissions and clear the /tmp directory files accumulated by AI-MOA.
+Consider installing the `aimoa-cron-maintenance.sh` script in sudoer's crontab to run periodically to fix permissions and clear the /tmp directory files accumulated by AI-MOA.
 
-```sudo crontab -e```
+`sudo crontab -e`
 
 Add the following to the crontab file:
 ```
@@ -443,7 +443,7 @@ sudo ./stop-llm.sh
 
 ### Clinic workflow suggestions ###
 
-AI-MOA is not 100% accurate in tagging documents to the correct patient. We recommend having a human medical office administrator review the tagged documents by AI-MOA daily for incorrect matches, and manually Refile the document to correct errors. A quick way to review tagged documents is to run a Search in InBox for All documents recently uploaded within a date range (ie. in the last day). The reviewer can use Rapid Review or Preview to review all the AI-MOA work. Pay attention to "Unassigned, Unassigned" documents; and also confirm that the patient name in the document corresponds to the correct demographic tagged in EMR. The reviewer can click "Acknowledge or Next" to confirm that it has been checked by a human. Any incorrect documents can be sent to Refile and manually corrected through the Incoming Docs document manager.
+AI-MOA is not 100% accurate in tagging documents to the correct patient. We recommend having a human medical office administrator act as `default_error_manager_id` to review the tagged documents by AI-MOA daily for incorrect matches, and manually Refile the document to correct errors. Unassigned or documents tagged to `default_unidentified_patient_tagging_id` will be also tagged to the medical office administrator (`default_error_manager_id`) to review in their InBox. A quick way to also review tagged documents is to run a Search in InBox for All documents recently uploaded within a date range (ie. in the last day). The reviewer can use Rapid Review or Preview to review all the AI-MOA work. Pay attention to "Unassigned, Unassigned" documents; and also confirm that the patient name in the document corresponds to the correct demographic tagged in EMR. The reviewer can click "Acknowledge or Next" to confirm that it has been checked by a human. Any incorrect documents can be sent to Refile and manually corrected through the Incoming Docs document manager.
 
 ### Uninstalling Aimee AI ###
 

--- a/install/Readme.md
+++ b/install/Readme.md
@@ -158,7 +158,7 @@ Follow online instructions to install Docker and Docker Compose.
 
 Or
 
-Use our custom "install-docker.sh" scrip to install automatically:
+Use our custom "install-docker.sh" script to install automatically:
 ```
 sudo ./install-docker.sh
 ```

--- a/install/fix-aimoa.sh
+++ b/install/fix-aimoa.sh
@@ -2,7 +2,7 @@
 # This script fixes some common errors with AI-MOA Note:
 # To correctly use automatic detection of AI-MOA path, this script must be installed and run in subdirectory 'gwc-aimee'
 # This install script should be run as 'sudo ./fix-aimoa.sh'
-# Version 2025.02.02
+# Version 2025.02.20
 
 # CONFIGURATION:
 CURRENT=$(pwd)
@@ -24,12 +24,12 @@ USERNAME=$(awk -F':' -v uid=1000 '$3 == uid { print $1 }' /etc/passwd)
 /bin/chown aimoa:aimoa $AIMOA/* -R
 /bin/chown aimoa:aimoa $AIMOA/.env/* -R -P
 # Fix permissions so AI MOA can read-write
-/bin/chmod ug+rwx $AIMOA/config $AIMOA/logs $AIMOA/.env $AIMOA/src/config
-/bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/* $AIMOA/.env/* $AIMOA/src/config/*.yaml
-/bin/chmod ug+rw $AIMOA/llm-container/models
+/bin/chmod ug+rwx $AIMOA/config $AIMOA/logs $AIMOA/.env $AIMOA/src/config $AIMOA/app/input $AIMOA/app/output
+/bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/* $AIMOA/.env/* $AIMOA/src/config/*.yaml $AIMOA/app/input/* $AIMOA/app/output/*
+/bin/chmod ug+rw $AIMOA/llm-container/models -R
 /bin/chmod ug+rw $AIMOA/src/*.lock $AIMOA/config/*.lock
 # Protect config.yaml from Other users
-/bin/chmod o-rwx $AIMOA/config
+/bin/chmod o-rwx $AIMOA/config $AIMOA/app $AIMOA/app/input $AIMOA/app/output
 
 /bin/echo "Confirming current user belonging to the following groups (check for 'aimoa')..."
 /usr/bin/groups $USER

--- a/install/install-aimoa.sh
+++ b/install/install-aimoa.sh
@@ -39,30 +39,30 @@ AIMOA=$(pwd)
 /bin/echo ""
 # Create the logs directory if it doesn't exist
 /bin/echo "Creating log directory..."
-/bin/mkdir -p $AIMOA/logs
+/bin/mkdir -p '$AIMOA/logs'
 
 # Create the static directory if it doesn't exist
 /bin/echo "Creating src/static directory..."
-/bin/mkdir -p $AIMOA/src/static
+/bin/mkdir -p '$AIMOA/src/static'
 
 # Create the config directory if it doesn't exit. For local configuration files.
 /bin/echo "Creating config directory"
-/bin/mkdir -p $AIMOA/config
+/bin/mkdir -p '$AIMOA/config'
 
 # Create the app directories if it doesn't exit. For local folder document processing.
 /bin/echo "Creating app directories"
-/bin/mkdir -p $AIMOA/app
-/bin/mkdir -p $AIMOA/app/input
-/bin/mkdir -p $AIMOA/app/output
+/bin/mkdir -p '$AIMOA/app'
+/bin/mkdir -p '$AIMOA/app/input'
+/bin/mkdir -p '$AIMOA/app/output'
 
 # Initialize permissions
-/bin/chmod g+rw $AIMOA/config -R
-/bin/chmod g+rw $AIMOA/app/ -R
-/bin/chmod g+rw $AIMOA/src/*
+/bin/chmod g+rw '$AIMOA/config' -R
+/bin/chmod g+rw '$AIMOA/app/' -R
+/bin/chmod g+rw '$AIMOA/src/*'
 
 # Create the llm-container/models directory if it doesn't exist
 /bin/echo "Creating llm-container/models directory..."
-/bin/mkdir -p $AIMOA/llm-container/models
+/bin/mkdir -p '$AIMOA/llm-container/models'
 
 # Backup config files
 /bin/echo "Backing up old config files..."

--- a/install/install-aimoa.sh
+++ b/install/install-aimoa.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # This custom script installs Get Well Clinic's version of AI-MOA (Aimee AI)
-# Note: To correctly use automatic detection of AI-MOA path, this script must be installed and run in subdirectory 'gwc-aimee'
+# Note: To correctly use automatic detection of AI-MOA path, this script must be installed and run in subdirectory 'install'
 # This install script should be run as 'sudo ./install-aimoa.sh'
-# Version 2025.02.02
+# Version 2025.02.21
 
 # Hardware Requirements:
 #	NVIDIA RTX video card installed with at least 12 GB VRAM
@@ -45,12 +45,19 @@ AIMOA=$(pwd)
 /bin/echo "Creating src/static directory..."
 /bin/mkdir -p $AIMOA/src/static
 
-# Create the config director if it doesn't exit
+# Create the config directory if it doesn't exit. For local configuration files.
 /bin/echo "Creating config directory"
 /bin/mkdir -p $AIMOA/config
 
+# Create the app directories if it doesn't exit. For local folder document processing.
+/bin/echo "Creating app directories"
+/bin/mkdir -p $AIMOA/app
+/bin/mkdir -p $AIMOA/app/input
+/bin/mkdir -p $AIMOA/app/output
+
 # Initialize permissions
 /bin/chmod g+rw $AIMOA/config -R
+/bin/chmod g+rw $AIMOA/app/ -R
 /bin/chmod g+rw $AIMOA/src/*
 
 # Create the llm-container/models directory if it doesn't exist
@@ -61,14 +68,18 @@ AIMOA=$(pwd)
 /bin/echo "Backing up old config files..."
 /bin/cp $AIMOA/src/config.yaml $AIMOA/src/config.yaml.$(date +'%Y-%m-%d')
 /bin/cp $AIMOA/config/config.yaml $AIMOA/config/config.yaml.$(date +'%Y-%m-%d')
+/bin/cp $AIMOA/config/config-incomingfax.yaml $AIMOA/config/config-incomingfax.yaml.$(date +'%Y-%m-%d')
 /bin/cp $AIMOA/src/workflow-config.yaml $AIMOA/src/workflow-config.yaml.$(date +'%Y-%m-%d')
 /bin/cp $AIMOA/config/workflow-config.yaml $AIMOA/config/workflow-config.yaml.$(date +'%Y-%m-%d')
+/bin/cp $AIMOA/config/workflow-config-incomingfax.yaml $AIMOA/config/workflow-config-incomingfax.yaml.$(date +'%Y-%m-%d')
 /bin/cp $AIMOA/config/provider_list.yaml $AIMOA/config/provider_list.yaml.$(date +'%Y-%m-%d')
 /bin/cp $AIMOA/src/config/provider_list.yaml $AIMOA/src/config/provider_list.yaml.$(date +'%Y-%m-%d')
 # Create config files in config directory
 /bin/echo "Creating config files from templates..."
 /bin/cp $AIMOA/src/config.yaml.example $AIMOA/config/config.yaml
+/bin/cp $AIMOA/src/config-incomingfax.yaml.example $AIMOA/config/config-incomingfax.yaml
 /bin/cp $AIMOA/src/workflow-config.yaml.example $AIMOA/config/workflow-config.yaml
+/bin/cp $AIMOA/src/workflow-config.yaml.example $AIMOA/config/workflow-config-incomingfax.yaml
 /bin/cp $AIMOA/src/template_providerlist.txt $AIMOA/config/
 /bin/echo "...remember to edit the config files in ../config/* to customize to your installation."
 # Initialize installation to re-fresh provider list
@@ -109,8 +120,8 @@ pip install -r $AIMOA/src/requirements.txt
 # Modify user:group permissions
 /bin/chown aimoa:aimoa $AIMOA/* -R
 # Fix permissions so AI MOA can read-write
-/bin/chmod ug+rwx $AIMOA/config $AIMOA/logs
-/bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/*
+/bin/chmod ug+rwx $AIMOA/config $AIMOA/logs $AIMOA/app $AIMOA/app/input $AIMOA/app/output
+/bin/chmod ug+rw $AIMOA/config/* $AIMOA/logs/* $AIMOA/app/input/* $AIMOA/app/output/*
 /bin/chmod ug+rw $AIMOA/llm-container/models
 # Protect config.yaml from Other users
 /bin/chmod o-rwx $AIMOA/config
@@ -126,9 +137,11 @@ pip install -r $AIMOA/src/requirements.txt
 /bin/chmod guo+x $AIMOA/install/*
 /bin/chmod o-x $AIMOA/install/install*
 /bin/chmod o-x $AIMOA/install/uninstall*
-# Protect config directory
+# Protect directories from Other Users
 /bin/echo "Protecting ../config directory..."
 /bin/chmod o-rwx $AIMOA/config
+/bin/echo "Protecting ../app directory..."
+/bin/chmod o-rwx $AIMOA/app -R
 
 # Install google-chrome
 /bin/echo "Installing Google Chrome for AI-MOA..."

--- a/install/install-services.sh
+++ b/install/install-services.sh
@@ -45,7 +45,7 @@ AIMOA=$(pwd)
 /usr/sbin/service ai-moa start
 /usr/sbin/service ai-moa-incomingfax start
 
-/bin/echo "ai-moa.service, aim-moa-incomingfax.service and llm-container.service has been installed as system services in /etc/systemd/system/"
+/bin/echo "ai-moa.service, ai-moa-incomingfax.service and llm-container.service has been installed as system services in /etc/systemd/system/"
 /bin/echo "AI-MOA will start automatically on system reboot !"
 /bin/echo ""
 # To stop services temporarily: 'sudo system ai-moa stop' , 'sudo system ai-moa-incomingfax stop', 'sudo system llm-container stop'

--- a/install/install-services.sh
+++ b/install/install-services.sh
@@ -3,13 +3,16 @@
 # This script should reside and be run in the AI-MOA subdirectory 'install' in order to properly autodetect base directory for AI-MOA.
 # Run the script as 'sudo ./install-services.sh'
 
-# Version 2025.02.02
+# Version 2025.02.21
 
 # Automatic detect base directory for AI-MOA:
 cd ..
 AIMOA=$(pwd)
 # Override to specify base directory for AI-MOA:
 # AIMOA=/opt/ai-moa
+
+/bin/echo "Installing AI-MOA services for 'ai-moa.service' and 'ai-moa-incomingfax.service' to autostart on system reboot..."
+/bin/echo ""
 
 # Confirm base directory:
 /bin/echo "Please confirm the correct base directory for AI-MOA as shown below..."
@@ -20,33 +23,39 @@ AIMOA=$(pwd)
 
 # Edit the AI-MOA services to match installed AI-MOA base directory:
 /bin/cp $AIMOA/install/services/ai-moa.service.default $AIMOA/install/services/ai-moa.service
+/bin/cp $AIMOA/install/services/ai-moa-incomingfax.service.default $AIMOA/install/services/ai-moa-incomingfax.service
 /bin/cp $AIMOA/install/services/llm-container.service.default $AIMOA/install/services/llm-container.service
 /bin/sed -i 's#/opt/ai-moa#'"$AIMOA"'#g' $AIMOA/install/services/ai-moa.service
+/bin/sed -i 's#/opt/ai-moa#'"$AIMOA"'#g' $AIMOA/install/services/ai-moa-incomingfax.service
 /bin/sed -i 's#/opt/ai-moa#'"$AIMOA"'#g' $AIMOA/install/services/llm-container.service
 
 # Install AI-MOA and LLM Container as system services in Linux:
 /bin/cp $AIMOA/install/services/ai-moa.service /etc/systemd/system/
+/bin/cp $AIMOA/install/services/ai-moa-incomingfax.service /etc/systemd/system/
 /bin/cp $AIMOA/install/services/llm-container.service /etc/systemd/system/
 # Reload any changes to system service folder /etc/systemd/system
 /usr/bin/systemctl daemon-reload
 
 # Enable system AI-MOA and LLM Container services:
 /usr/bin/systemctl enable ai-moa.service
+/usr/bin/systemctl enable ai-moa-incomingfax.service
 /usr/bin/systemctl enable llm-container.service
 # Start system services:
 /usr/sbin/service llm-container start
 /usr/sbin/service ai-moa start
+/usr/sbin/service ai-moa-incomingfax start
 
-/bin/echo "ai-moa.service and llm-container.service has been installed as system services in /etc/systemd/system/"
+/bin/echo "ai-moa.service, aim-moa-incomingfax.service and llm-container.service has been installed as system services in /etc/systemd/system/"
 /bin/echo "AI-MOA will start automatically on system reboot !"
 /bin/echo ""
-# To stop services temporarily: 'sudo system ai-moa stop' , 'sudo system llm-container stop'
+# To stop services temporarily: 'sudo system ai-moa stop' , 'sudo system ai-moa-incomingfax stop', 'sudo system llm-container stop'
+
 /bin/echo "	Tips:"
-/bin/echo "		to stop AI-MOA 'sudo system ai-moa stop'"
-/bin/echo "		to start AI-MOA 'sudo system ai-moa start'"
+/bin/echo "		to stop AI-MOA 'sudo system ai-moa stop', and 'sudo system ai-moa-incomingfax stop'"
+/bin/echo "		to start AI-MOA 'sudo system ai-moa start', and 'sudo system ai-moa-incomingfax start'"
 /bin/echo "		to check NVIDIA GPU 'nvidia-smi'"
-/bin/echo "		to disable AI-MOA from restarting on reboot 'sudo systemctl disable ai-moa.service'"
-/bin/echo "		to re-enable AI-MOA to restart automatically on reboot 'sudo systemctl enable ai-moa.service'"
+/bin/echo "		to disable AI-MOA from restarting on reboot 'sudo systemctl disable ai-moa.service' and 'sudo systemctl disable ai-moa-incomingfax.service'"
+/bin/echo "		to re-enable AI-MOA to restart automatically on reboot 'sudo systemctl enable ai-moa.service', and 'sudo systemctl enable ai-moa-incomingfax.service'"
 /bin/echo ""
 
-# To disable system services, and prevent from restarting on reboot: 'sudo systemctl disable ai-moa.service' , 'sudo systemctl disable llm-container.service'
+# To disable system services, and prevent from restarting on reboot: 'sudo systemctl disable ai-moa.service' , 'sudo systemctl disable ai-moa-incomingfax.service', 'sudo systemctl disable llm-container.service'

--- a/install/run-aimoa-incomingfax.sh
+++ b/install/run-aimoa-incomingfax.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Startup script for AI-MOA
+
+# Version 2025.02.21
+
+# CONFIGURATION:
+# Automatic configuration of paths:
+CURRENT=$(pwd)
+cd ..
+AIMOA=$(pwd)
+AIPYTHONENV=$(pwd)/.env
+# Override by specifying the full path for AI-MOA base directory and Python virtual environment that contains the installed python pre-requisite packages:
+# AIMOA=/opt/ai-moa
+# AIPYTHONENV=/opt/virtualenv/aimoa
+
+# Confirm base directory of AI-MOA:
+/bin/echo "Currently specifying the following as the base directory for AI-MOA..."
+/bin/echo $AIMOA
+/bin/echo ""
+/bin/echo "This 'run-aimoa-incomingfax.sh' is for starting AI-MOA by command line. You do not need to run this if you have installed AI-MOA as a system service."
+/bin/echo "	( Hint: To install AI-MOA as a system service, execute 'sudo ./install-aimoa.sh' )"
+/bin/sleep 3s
+
+# Activate Python virtual environment with installed pre-requisite packages
+source $AIPYTHONENV/bin/activate
+
+# Export environment variables specifying location of config files
+export CONFIG_FILE=$AIMOA/config/config-incomingfax.yaml
+export WORKFLOW_CONFIG_FILE=$AIMOA/config/workflow-config-incomingfax.yaml
+
+# Option to disable warnings when using a self-signed SSL certificate for servers, quiet the logging
+export PYTHONWARNINGS="ignore:Unverified HTTPS request"
+
+# Display environment variables on console
+/bin/echo "Specifying the following environmental variables for AI-MOA..."
+/bin/echo $CONFIG_FILE
+/bin/echo $WORKFLOW_CONFIG_FILE
+/bin/echo $PYTHONWARNINGS
+
+# Initialize permissions (otherwise AI-MOA can't read-wrote config files, or save provider list)
+#/bin/chown aimoa:aimoa $AIMOA/src/*
+#/bin/chown aimoa:aimoa $AIMOA/config/*
+#/bin/chmod g+rw $AIMOA/config -R
+#/bin/chmod g+rw $AIMOA/src/*
+
+# Command to start AI-MOA
+/bin/echo "Starting AI-MOA..."
+# main version
+cd $AIMOA/src
+python3 main.py --config $AIMOA/config/config-incomingfax.yaml --workflow-config $AIMOA/config/workflow-config-incomingfax.yaml --reset-lock --cron-interval */1 --run-immediately
+# (huey version)
+# huey_consumer main.huey
+
+# Returning to previous path location
+cd $CURRENT

--- a/install/services/ai-moa-incomingfax.service
+++ b/install/services/ai-moa-incomingfax.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Aimee AI (AI-MOA) IncomingDocs/Fax
+After=network.target
+
+# Assumes the path to AI-MOA base directory is '/opt/ai-moa'; if different, please edit ExecStart and ExecStop paths below:
+
+[Service]
+# AI-MOA can run as user 'aimoa' if permissions set properly on all subdirectory and files in AI-MOA
+User=aimoa
+Nice=1
+KillMode=control-group
+# KillMode=none
+# KillMode=mixed
+SuccessExitStatus=0 1
+# RemainAfterExit=true
+# ProtectHome=true
+# ProtectSystem=full
+# PrivateDevices=true
+# NoNewPrivileges=true
+WorkingDirectory=/opt/ai-moa/src
+# Edit the path to AI-MOA/gwc-aimee:
+ExecStart=/opt/ai-moa/install/run-aimoa-incomingfax.sh
+KillSignal=SIGINT
+# ExecStop=
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target
+

--- a/install/services/ai-moa-incomingfax.service.default
+++ b/install/services/ai-moa-incomingfax.service.default
@@ -1,0 +1,30 @@
+[Unit]
+Description=Aimee AI (AI-MOA) IncomingDocs/Fax
+After=network.target
+
+# Assumes the path to AI-MOA base directory is '/opt/ai-moa'; if different, please edit ExecStart and ExecStop paths below:
+
+[Service]
+# AI-MOA can run as user 'aimoa' if permissions set properly on all subdirectory and files in AI-MOA
+User=aimoa
+Nice=1
+KillMode=control-group
+# KillMode=none
+# KillMode=mixed
+SuccessExitStatus=0 1
+# RemainAfterExit=true
+# ProtectHome=true
+# ProtectSystem=full
+# PrivateDevices=true
+# NoNewPrivileges=true
+WorkingDirectory=/opt/ai-moa/src
+# Edit the path to AI-MOA/gwc-aimee:
+ExecStart=/opt/ai-moa/install/run-aimoa-incomingfax.sh
+KillSignal=SIGINT
+# ExecStop=
+Restart=on-failure
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target
+

--- a/install/watch-aimoa-incomingfax-logs.sh
+++ b/install/watch-aimoa-incomingfax-logs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Follow AI-MOA logs in real-time
+/bin/echo ""
+/bin/echo "Watching AI-MOA workflow-incomingfax.logs in realtime..."
+/bin/echo "	(To stop watching and exit, press Ctrl-C)"
+/bin/echo ""
+/usr/bin/journalctl --follow -u ai-moa-incomingfax.service

--- a/src/config-incomingfax.yaml.example
+++ b/src/config-incomingfax.yaml.example
@@ -1,0 +1,120 @@
+# COPYRIGHT © 2024 by Spring Health Corporation <office(at)springhealth.org>
+# Toronto, Ontario, Canada
+# SUMMARY: This file is part of the Get Well Clinic's original "AI-MOA" project's collection of software,
+# documentation, and configuration files.
+# These programs, documentation, and configuration files are made available to you as open source
+# in the hopes that your clinic or organization may find it useful and improve your care to the public
+# by reducing administrative burden for your staff and service providers.
+# NO WARRANTY: This software and related documentation is provided "AS IS" and WITHOUT ANY WARRANTY of any kind;
+# and WITHOUT EXPRESS OR IMPLIED WARRANTY OF SUITABILITY, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+# LICENSE: This software is licensed under the "GNU Affero General Public License Version 3".
+# Please see LICENSE file for full details. Or contact the Free Software Foundation for more details.
+# ***
+# NOTICE: We hope that you will consider contributing to our common source code repository so that
+# others may benefit from your shared work.
+# However, if you distribute this code or serve this application to users in modified form,
+# or as part of a derivative work, you are required to make your modified or derivative work
+# source code available under the same herein described license.
+# Please notify Spring Health Corp <office(at)springhealth.org> where your modified or derivative work
+# source code can be acquired publicly in its latest most up-to-date version, within one month.
+# ***
+
+# AI configuration for interacting with the AI-MOA service.
+# Version: 2025.02.21
+
+ai:
+  uri: https://localhost:3334/v1/chat/completions  # URI endpoint for AI model interactions.
+  verify-HTTPS: false
+
+# AI-MOA document processor configuration.
+aimoa_document_processor:
+  type: o19  # Type of document processor being used. (ie. 'o19', 'o15' or 'local')
+
+# Chrome browser configuration for headless operation.
+chrome:
+  options:
+    headless: true  # Whether to run Chrome in headless mode (without GUI). 'false' means it will run with a GUI.
+
+# Document processing configuration, including directories for input files.
+document_processor:
+  local:
+    input_directory: ../app/input  # Directory where input files for document processing are stored.
+  system_type: local  # Type of system. (ie 'local')
+
+# EMR (Electronic Medical Record) configuration for connecting to an EMR system.
+emr:
+  base_url: http://127.0.0.1:8080/oscar  # Base URL for the EMR system.
+  verify-HTTPS: false   # This flag allows for ignoring warnings for self-signed TLS/SSL certificates in a development environment.
+  document_folder: incoming  # Folder where pending documents to be processed are stored in o19. (ie. 'pending', or 'incoming')
+  incoming_folder: Fax  # Folder where incoming documents to be processed are stored in o19. (ie. 'Fax', 'File', 'Mail', or 'Refile')
+  incoming_folder_queue: '1'  # Queue number for processing incoming files. (ie. '1', '2' etc.)
+  password: passpwd  # Password for EMR login.
+  pin: '123'  # PIN for EMR login.
+  system_type: o19  # Type of system. (ie. 'o19', or 'o15')
+  username: emr  # Username for EMR login.
+
+general_setting:
+  timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.
+
+# File processing configuration, defining allowed file extensions and directories for input/output.
+file_processing:
+  allowed_extensions:
+    - .pdf   # Allowed file extensions for processing.
+    - .jpg
+    - .png
+    - .tiff
+  incoming_retries: 0  # Number of retries for incoming files before giving up.
+  input_directory: ../app/input  # Directory for incoming files to be processed.
+  max_retries: 3  # Maximum retries for file processing before failure.
+  output_directory: ../app/output  # Directory where processed files are output.
+  pending_retries: 1  # Number of retries for the current file in processing.
+
+# Huey configuration for task scheduling and logging.
+huey:
+  always_eager: true  # If true, tasks will be executed immediately without waiting for the scheduled time.
+  console_level: INFO  # Log level for console output. (ie. INFO, DEBUG, WARN, ERROR, FATAL etc. )
+  file_level: INFO  # Log level for file output. (ie. INFO, DEBUG etc. )
+  name: IncomingDocs-Fax_queue  # Name of the task queue.
+  results: true  # If true, task results will be stored.
+  store_none: false  # Whether or not to store task results.
+  
+# Inbox configuration.
+inbox:
+  pending: 99999999  # Last processed file ID in the inbox, should be set to your last AI-MOA processed/completed file in the inbox.
+  incoming: '2125-01-01 00:00:00' # Timestamp for the last processed file for incoming documents folder, should follow this format and should be set to a value inorder to process files in incoming documents folder.
+
+# LLM (Large Language Model) configuration, including model parameters for AI interactions.
+llm:
+  character: Assistant  # Character or role the AI model will take (Assistant).
+  chat_template: '{{ bos_token }}{% for message in messages %}{% if (message[''role'']
+    == ''user'') != (loop.index0 % 2 == 0) %}{{ raise_exception(''Conversation roles
+    must alternate user/assistant/user/assistant...'') }}{% endif %}{% if message[''role'']
+    == ''user'' %}{{ ''[INST] '' + message[''content''] + '' [/INST]'' }}{% elif message[''role'']
+    == ''assistant'' %}{{ message[''content''] + eos_token}}{% else %}{{ raise_exception(''Only
+    user and assistant roles are supported!'') }}{% endif %}{% endfor %}'
+  model: /models/Mistral-7B-Instruct-v0.3.Q8_0.gguf  # Path to the model file being used.
+  temperature: 0.1  # Temperature for controlling the randomness of model responses.
+  top_p: 0.1  # Top-p sampling for controlling diversity of responses (related to nucleus sampling).
+  log_responses: false     # set to true to see LLM output in console
+
+# Lock configuration, to control access to shared resources.
+lock:
+  status: false  # Indicates whether a lock is active or not (false means no lock). If AI-MOA running but not processing, reset lock status to 'false'.
+
+# Logging configuration, including file location, format, and log level.
+logging:
+  console_level: INFO   # Log level for console output. (ie. INFO, DEBUG, WARN, ERROR, FATAL etc. )
+  file_level: INFO  # Log level for file output. (ie. INFO, DEBUG etc. )
+  filename: ../logs/workflow-incomingfax.log  # Log file location.
+  format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'  # Log format.
+
+# OCR (Optical Character Recognition) configuration, specifying the device and settings for document scanning.
+ocr:
+  device: cuda:0  # Device used for OCR processing.
+  enable_gpu: true  # Whether to enable GPU support for OCR (faster processing).
+  page_limit: 10  # Maximum number of pages to process in OCR; if the document exceeds this limit, additional pages will be ignored.
+
+# Provider list configuration, for generating or managing provider data.
+provider_list:
+  output_file: ../config/provider_list.yaml  # Config file for list of clinic providers that AI-MOA will recognize and tag. Manually edit and clean up extraneous providers in this generated list.
+  template_file: ../config/template_providerlist.txt  # Template file for Query By Template to extract sample provider list and output to 'output_file'.

--- a/src/config.yaml.example
+++ b/src/config.yaml.example
@@ -20,7 +20,7 @@
 # ***
 
 # AI configuration for interacting with the AI-MOA service.
-# Version: 2025.02.02
+# Version: 2025.02.21
 
 ai:
   uri: https://localhost:3334/v1/chat/completions  # URI endpoint for AI model interactions.
@@ -28,33 +28,33 @@ ai:
 
 # AI-MOA document processor configuration.
 aimoa_document_processor:
-  type: o19  # Type of document processor being used, 'o19', 'o15' or 'local'.
+  type: o19  # Type of document processor being used. (ie. 'o19', 'o15' or 'local')
 
 # Chrome browser configuration for headless operation.
 chrome:
   options:
-    headless: true  # Whether to run Chrome in headless mode (without GUI). False means it will run with a GUI.
+    headless: true  # Whether to run Chrome in headless mode (without GUI). 'false' means it will run with a GUI.
 
 # Document processing configuration, including directories for input files.
 document_processor:
   local:
     input_directory: ../app/input  # Directory where input files for document processing are stored.
-  system_type: local  # Type of system, 'local'.
+  system_type: local  # Type of system. (ie 'local')
 
 # EMR (Electronic Medical Record) configuration for connecting to an EMR system.
 emr:
   base_url: http://127.0.0.1:8080/oscar  # Base URL for the EMR system.
-  verify-HTTPS: false
-  document_folder: pending  # Folder where pending documents to be processed are stored in o19.
-  incoming_folder: File  # Folder where incoming documents to be processed are stored in o19.
-  incoming_folder_queue: '1'  # Queue number for processing incoming files.
+  verify-HTTPS: false   # This flag allows for ignoring warnings for self-signed TLS/SSL certificates in a development environment.
+  document_folder: pending  # Folder where pending documents to be processed are stored in o19. (ie. 'pending', or 'incoming')
+  incoming_folder: Fax  # Folder where incoming documents to be processed are stored in o19. (ie. 'Fax', 'File', 'Mail', or 'Refile')
+  incoming_folder_queue: '1'  # Queue number for processing incoming files. (ie. '1', '2' etc.)
   password: passpwd  # Password for EMR login.
   pin: '123'  # PIN for EMR login.
-  system_type: o19  # Type of system, 'o19', 'o15'.
+  system_type: o19  # Type of system. (ie. 'o19', or 'o15')
   username: emr  # Username for EMR login.
 
 general_setting:
-  timeout: 300 # Timeout for request (POST and GET) to avoid indefinitely hanging requests.
+  timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.
 
 # File processing configuration, defining allowed file extensions and directories for input/output.
 file_processing:
@@ -99,7 +99,7 @@ llm:
 
 # Lock configuration, to control access to shared resources.
 lock:
-  status: false  # Indicates whether a lock is active or not (false means no lock). If AI-MOA running but not processing, reset lock status to false.
+  status: false  # Indicates whether a lock is active or not (false means no lock). If AI-MOA running but not processing, reset lock status to 'false'.
 
 # Logging configuration, including file location, format, and log level.
 logging:
@@ -116,5 +116,5 @@ ocr:
 
 # Provider list configuration, for generating or managing provider data.
 provider_list:
-  output_file: ../config/provider_list.yaml  # Output file for storing the provider list.
-  template_file: ../config/template_providerlist.txt  # Template file for provider list formatting.
+  output_file: ../config/provider_list.yaml  # Config file for list of clinic providers that AI-MOA will recognize and tag. Manually edit and clean up extraneous providers in this generated list.
+  template_file: ../config/template_providerlist.txt  # Template file for Query By Template to extract sample provider list and output to 'output_file'.


### PR DESCRIPTION
- updated installation scripts so default installation will have two workflow processes concurrently installed as services, one processing PendingDocs, the other processing IncomingDocs/Fax.

## Summary by Sourcery

This update modifies the installation process to support concurrent processing of PendingDocs and IncomingDocs/Fax by setting up two separate services. It also includes enhancements to directory structure, configuration file handling, and system service management.

New Features:
- Adds support for processing both PendingDocs and IncomingDocs/Fax concurrently by installing two workflow processes as services.

Enhancements:
- The installation script now creates 'app' directories for local folder document processing, including 'input' and 'output' subdirectories.
- The install script now backs up the config-incomingfax.yaml and workflow-config-incomingfax.yaml files before creating new config files from templates.

Build:
- The installation script now installs two services: 'ai-moa.service' for processing PendingDocs and 'ai-moa-incomingfax.service' for processing IncomingDocs/Fax.
- The installation script now includes a cron job script (`aimoa-cron-maintenance.sh`) to fix permissions and clear temporary files.

CI:
- The install script now installs AI-MOA services for 'ai-moa.service' and 'ai-moa-incomingfax.service' to autostart on system reboot.

Chores:
- The installation script has been updated to include a step to protect the 'app' directory from access by other users.