### PR TITLE
Update aimoa-cron-maintenance.sh for shorter mtime

### DIFF
--- a/install/aimoa-cron-maintenance.sh
+++ b/install/aimoa-cron-maintenance.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # This script periodically clears /tmp director of temporary Chrome/Chromium temp files
 # and fixes permission to AI-MOA config files
-# Version 2025.02.18
+# Version 2025.03.22
 # Instructions: Edit and confirm location of AI-MOA install scripts; and then install this to crontab with "sudo crontab -e" to run periodically
 # 0 6 * * * /opt/ai-moa/install/aimoa-cron-maintenance.sh
 
 # CONFIG
-# Files to delete older than how many days:
-DAYS=1
+# Files to delete older than how many days: (0.05 days is 1.2 hrs)
+DAYS=0.05
 # AI-MOA group user
 GROUP=aimoa
 # Path of AI-MOA (Please confirm/edit)


### PR DESCRIPTION
Update aimoa-cron-maintenance.sh for shorter mtime to delete /tmp files, to prevent running out of disk space and creation of zero byte config.yaml resulting in crash.

## Summary by Sourcery

Enhancements:
- Reduce the file deletion threshold in aimoa-cron-maintenance.sh from 1 day to 0.05 days to prevent disk space issues and avoid creation of zero-byte config.yaml files.