### PR TITLE
opro parameter to process all status of pendingdocs

### DIFF
--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -80,7 +80,7 @@ class LoginManager:
         :return: The current URL after login attempt.
         :rtype: str
         """
-        logger.info(f"Attempting Selenium login for user.")
+        logger.info("Attempting Selenium login for user.")
 
         logger.debug(f"Attempting Selenium login for user: {self.username[:2]}*****")
         

--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -168,9 +168,8 @@ class LoginManager:
 
         if flag:
             session = self.get_driver_session(session, driver)
-            return session, driver, flag
-        else:
-            return session, driver, flag
+
+        return session, driver, flag
 
     def is_login_successful(self, current_url):
         """

--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -82,8 +82,7 @@ class LoginManager:
         """
         logger.info(f"Attempting Selenium login for user.")
 
-        # Print is used to avoid logging username into log file.
-        print(f"Attempting Selenium login for user: {self.username[:2]}*****")
+        logger.debug(f"Attempting Selenium login for user: {self.username[:2]}*****")
         
         need_pin_field = self.config.get('emr.login_pin_field', False)
         system_type = self.config.get('emr.system_type', 'o19')

--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -83,7 +83,7 @@ class LoginManager:
         logger.info(f"Attempting Selenium login for user.")
 
         # Print is used to avoid logging username into log file.
-        print(f"Attempting Selenium login for user: {self.username}")
+        print(f"Attempting Selenium login for user: {self.username[:2]}*****")
         
         need_pin_field = self.config.get('emr.login_pin_field', False)
         system_type = self.config.get('emr.system_type', 'o19')

--- a/src/config.yaml.example
+++ b/src/config.yaml.example
@@ -53,6 +53,7 @@ emr:
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   system_type: o19  # Type of system. (ie. 'o19', 'openo', 'opro' or 'o15')
   username: emr  # Username for EMR login.
+  opro_pendingdocs_ids_auto_increment: false # Set to True to fetch all documents from OPRO; this will retrieve documents by incrementing the pending document ID by 1.
   tag_skipped_files: true # If set to True, the system will tag the document to the default patient when it reaches the maximum retries and skip the file.
 
 general_setting:

--- a/src/processors/o19/__init__.py
+++ b/src/processors/o19/__init__.py
@@ -20,6 +20,6 @@
 # ***
 
 from .o19_updater import update_o19, view_output
-from .o19_inbox import check_lock, release_lock, get_document_processor_type, get_o19_documents, get_inbox_pendingdocs_documents, get_inbox_incomingdocs_documents
+from .o19_inbox import check_lock, release_lock, get_document_processor_type, get_o19_documents, get_inbox_pendingdocs_documents, get_inbox_incomingdocs_documents, get_inbox_pendingdocs_documents_opro
 
-__all__ = ['view_output', 'update_o19', 'check_lock', 'release_lock', 'get_inbox_pendingdocs_documents','get_inbox_incomingdocs_documents']
+__all__ = ['view_output', 'update_o19', 'check_lock', 'release_lock', 'get_inbox_pendingdocs_documents','get_inbox_incomingdocs_documents', 'get_inbox_pendingdocs_documents_opro']

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -106,7 +106,7 @@ def get_o19_documents(self):
 
 	if system_type == 'pending':
 		system_type = self.config.get('emr.system_type', 'o19')
-		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_verify', False)
+		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_auto_increment', False)
 		if system_type == 'opro' and verify_document_ids:
 			"""
 			This is to fix the null status in the 'opro' queue_document_link table.

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -105,7 +105,16 @@ def get_o19_documents(self):
 	system_type = self.config.get('emr.document_folder')
 
 	if system_type == 'pending':
-		return self.get_inbox_pendingdocs_documents(self)
+		system_type = self.config.get('emr.system_type', 'o19')
+		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_verify', False)
+		if system_type == 'o19' and verify_document_ids:
+			"""
+			This is to fix the null status in the 'opro' queue_document_link table.
+			It should be removed immediately once the aforementioned issue is resolved.
+			"""
+			return self.get_inbox_pendingdocs_documents_opro(self)
+		else:
+			return self.get_inbox_pendingdocs_documents(self)
 	elif system_type == 'incoming':
 		return self.get_inbox_incomingdocs_documents(self)
 
@@ -137,7 +146,7 @@ def get_inbox_pendingdocs_documents(self):
 			driver.get(f"{self.base_url}/dms/inboxManage.do?method=getDocumentsInQueues")
 		
 		try:
-			driver.implicitly_wait(300)
+			driver.implicitly_wait(115)
 			queuenames_field = driver.find_element(By.ID, "queueNames")
 		except TimeoutException:
 			self.logger.debug("Timeout occurred when loading pending documents.")
@@ -276,3 +285,56 @@ def get_inbox_incomingdocs_documents(self):
 							self.logger.error(f"An error occurred: {file_response.status_code}")
 							return False
 	return False
+
+
+def get_inbox_pendingdocs_documents_opro(self):
+	"""
+    Fetch and process the next pending EMR document from the inbox for opro to resolve null in queue_document_link.
+
+    This method increments the next document number to process based on the last
+    processed file recorded in the configuration. It constructs a request to fetch
+    the document from the DMS, handles retry logic based
+    on configurable limits, and updates the processing state accordingly.
+
+    Returns:
+        bool: True if a document was successfully fetched and ready for processing;
+              False if no documents are left, if an error occurred, or if the document
+              should be skipped after exceeding retry limits.
+    """
+	pending_file = self.config.get('inbox.pending')
+	item = 0
+	if pending_file is None:
+		self.logger.info(f"Pending documents last processed file details missing in configuration.")
+		return False
+	else:
+		last_processed_file = int(pending_file)
+		item = last_processed_file + 1
+
+	max_retries = self.config.get('file_processing.max_retries')  # Get max retry count from configuration
+	current_retries = self.config.get('file_processing.pending_retries')  # Get current retry count from configuration
+	
+	file_url = f"{self.base_url}/dms/ManageDocument.do?method=display&doc_no={item}"
+	self.headers['Referer'] = file_url
+	self.session.headers.update(self.headers)
+	file_response = self.session.get(file_url, verify=self.config.get('emr.verify-HTTPS'), timeout=self.config.get('general_setting.timeout', 300))
+
+	if file_response.status_code == 200 and file_response.content:
+		if max_retries <= current_retries:  # If max retries is equal to current retries
+			self.config.update_pending_retries(0)  # Reset the retry count in the configuration
+			tag_skipped_files = self.config.get('emr.tag_skipped_files')
+			if tag_skipped_files:
+				self.file_name = item
+			else:
+				self.config.update_pending_inbox(item)
+				self.logger.info(f"Max retries exceeded for processing. Skipping document No: {item}.")
+				return False
+		else:
+			self.config.update_pending_retries(current_retries + 1)
+			self.config.set_shared_state('current_file', file_response.content)
+			self.file_name = item
+			self.logger.info(f"Fetched EMR document from Pending Docs...Processing Document No: {item}.")
+			return True
+	else:
+		self.logger.info(f"No more documents to process or error while fetching document {item}.")
+	return False
+

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -107,7 +107,7 @@ def get_o19_documents(self):
 	if system_type == 'pending':
 		system_type = self.config.get('emr.system_type', 'o19')
 		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_verify', False)
-		if system_type == 'o19' and verify_document_ids:
+		if system_type == 'opro' and verify_document_ids:
 			"""
 			This is to fix the null status in the 'opro' queue_document_link table.
 			It should be removed immediately once the aforementioned issue is resolved.

--- a/src/processors/workflow/emr_workflow.py
+++ b/src/processors/workflow/emr_workflow.py
@@ -108,6 +108,7 @@ class Workflow:
         self.get_document_processor_type = o19_inbox.get_document_processor_type
         self.get_o19_documents = o19_inbox.get_o19_documents
         self.get_inbox_pendingdocs_documents = o19_inbox.get_inbox_pendingdocs_documents
+        self.get_inbox_pendingdocs_documents_opro = o19_inbox.get_inbox_pendingdocs_documents_opro
         self.get_inbox_incomingdocs_documents = o19_inbox.get_inbox_incomingdocs_documents
         self.get_local_documents = local_files.get_local_documents
         self.has_ocr = ocr.has_ocr


### PR DESCRIPTION
- implemented some suggestions from Sourcery AI
- added new parameter to enable opro processing of all pendingdocs regardless of active/inactive status

## Summary by Sourcery

Add a configuration option to process 'opro' pending documents sequentially by ID as a temporary workaround for a database issue.

New Features:
- Introduce a dedicated document fetching method for 'opro' systems, enabled via the `emr.opro_pendingdocs_ids_auto_increment` configuration flag.

Bug Fixes:
- Address potential null statuses in the 'opro' `queue_document_link` table by fetching documents sequentially when the new mode is enabled.

Enhancements:
- Decrease the implicit wait time when fetching standard pending documents.

Chores:
- Mask username in debug logs during Selenium login.
- Update internal references and exports to include the new document fetching method.