### PR TITLE
Fix for opro null state for pending documents

### DIFF
--- a/llm-container/docker-compose.yml
+++ b/llm-container/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     command: --model ${MODEL_NAME:-/models/gemma-2-2b-it} --enable-chunked-prefill --max_model_len 20000 --gpu_memory_utilization 0.8
     # For 16 GB VRAM GPU, you can set a lower --gpu_memory_utilization 0.625 for ~10 GB usage of VRAM:
     # command: --model ${MODEL_NAME:-/models/gemma-2-2b-it} --enable-chunked-prefill --max_model_len 20000 --gpu_memory_utilization 0.625
+    # For 24 GB VRAM GPU, you can set a lower --gpu_memory_utilization 0.42 for ~10 GB usage of VRAM:
+    # command: --model ${MODEL_NAME:-/models/gemma-2-2b-it} --enable-chunked-prefill --max_model_len 20000 --gpu_memory_utilization 0.42
   caddy:
     # Service for the Caddy container
     container_name: caddy-llm-container # Name of the container

--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -80,7 +80,7 @@ class LoginManager:
         :return: The current URL after login attempt.
         :rtype: str
         """
-        logger.info(f"Attempting Selenium login for user.")
+        logger.info("Attempting Selenium login for user.")
 
         logger.debug(f"Attempting Selenium login for user: {self.username[:2]}*****")
         

--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -168,9 +168,8 @@ class LoginManager:
 
         if flag:
             session = self.get_driver_session(session, driver)
-            return session, driver, flag
-        else:
-            return session, driver, flag
+
+        return session, driver, flag
 
     def is_login_successful(self, current_url):
         """

--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -82,8 +82,7 @@ class LoginManager:
         """
         logger.info(f"Attempting Selenium login for user.")
 
-        # Print is used to avoid logging username into log file.
-        print(f"Attempting Selenium login for user: {self.username[:2]}*****")
+        logger.debug(f"Attempting Selenium login for user: {self.username[:2]}*****")
         
         need_pin_field = self.config.get('emr.login_pin_field', False)
         system_type = self.config.get('emr.system_type', 'o19')

--- a/src/auth/login_manager.py
+++ b/src/auth/login_manager.py
@@ -83,7 +83,7 @@ class LoginManager:
         logger.info(f"Attempting Selenium login for user.")
 
         # Print is used to avoid logging username into log file.
-        print(f"Attempting Selenium login for user: {self.username}")
+        print(f"Attempting Selenium login for user: {self.username[:2]}*****")
         
         need_pin_field = self.config.get('emr.login_pin_field', False)
         system_type = self.config.get('emr.system_type', 'o19')

--- a/src/config-incomingfax.yaml.example
+++ b/src/config-incomingfax.yaml.example
@@ -20,7 +20,7 @@
 # ***
 
 # AI configuration for interacting with the AI-MOA service.
-# Version: 2025.04.09
+# Version: 2025.05.02
 
 ai:
   uri: https://localhost:3334/v1/chat/completions  # URI endpoint for AI model interactions.
@@ -54,6 +54,7 @@ emr:
   pin: '123'  # PIN for EMR login.
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   tag_skipped_files: true # If set to True, the system will tag the document to the default_unidentified_patient when it reaches the maximum retries and skip the file.
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' setting user-agent
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/config-incomingfile.yaml.example
+++ b/src/config-incomingfile.yaml.example
@@ -20,7 +20,7 @@
 # ***
 
 # AI configuration for interacting with the AI-MOA service.
-# Version: 2025.04.09
+# Version: 2025.05.02
 
 ai:
   uri: https://localhost:3334/v1/chat/completions  # URI endpoint for AI model interactions.
@@ -54,6 +54,7 @@ emr:
   pin: '123'  # PIN for EMR login.
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   tag_skipped_files: true # If set to True, the system will tag the document to the default_unidentified_patient when it reaches the maximum retries and skip the file.
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' setting user-agent
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/config.yaml.example
+++ b/src/config.yaml.example
@@ -20,7 +20,7 @@
 # ***
 
 # AI configuration for interacting with the AI-MOA service.
-# Version: 2025.04.08
+# Version: 2025.05.02
 
 ai:
   uri: https://localhost:3334/v1/chat/completions  # URI endpoint for AI model interactions.
@@ -53,10 +53,9 @@ emr:
   password: passpwd  # Password for EMR login.
   pin: '123'  # PIN for EMR login.
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
-  opro_pendingdocs_ids_auto_increment: false # Set to True to fetch all documents from OPRO; this will retrieve documents by incrementing the pending document ID by 1.
+  opro_pendingdocs_ids_auto_increment: false # Set to True to fetch all pending documents from opro, not just Active pending docs; this will retrieve documents by incrementing the pending document ID by 1.
   tag_skipped_files: true # If set to True, the system will tag the document to the default patient when it reaches the maximum retries and skip the file.
   user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' setting user-agent
-  tag_skipped_files: true # If set to True, the system will tag the document to default_unidentified_patient when it reaches the maximum retries and skip the file.
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/config.yaml.example
+++ b/src/config.yaml.example
@@ -53,6 +53,7 @@ emr:
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   system_type: o19  # Type of system. (ie. 'o19', 'openo', 'opro' or 'o15')
   username: emr  # Username for EMR login.
+  opro_pendingdocs_ids_auto_increment: false # Set to True to fetch all documents from OPRO; this will retrieve documents by incrementing the pending document ID by 1.
   tag_skipped_files: true # If set to True, the system will tag the document to the default patient when it reaches the maximum retries and skip the file.
 
 general_setting:

--- a/src/config.yaml.example
+++ b/src/config.yaml.example
@@ -55,6 +55,7 @@ emr:
   username: emr  # Username for EMR login.
   opro_pendingdocs_ids_auto_increment: false # Set to True to fetch all documents from OPRO; this will retrieve documents by incrementing the pending document ID by 1.
   tag_skipped_files: true # If set to True, the system will tag the document to the default patient when it reaches the maximum retries and skip the file.
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' setting user-agent
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/processors/o19/__init__.py
+++ b/src/processors/o19/__init__.py
@@ -20,6 +20,6 @@
 # ***
 
 from .o19_updater import update_o19, view_output
-from .o19_inbox import check_lock, release_lock, get_document_processor_type, get_o19_documents, get_inbox_pendingdocs_documents, get_inbox_incomingdocs_documents
+from .o19_inbox import check_lock, release_lock, get_document_processor_type, get_o19_documents, get_inbox_pendingdocs_documents, get_inbox_incomingdocs_documents, get_inbox_pendingdocs_documents_opro
 
-__all__ = ['view_output', 'update_o19', 'check_lock', 'release_lock', 'get_inbox_pendingdocs_documents','get_inbox_incomingdocs_documents']
+__all__ = ['view_output', 'update_o19', 'check_lock', 'release_lock', 'get_inbox_pendingdocs_documents','get_inbox_incomingdocs_documents', 'get_inbox_pendingdocs_documents_opro']

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -106,7 +106,7 @@ def get_o19_documents(self):
 
 	if system_type == 'pending':
 		system_type = self.config.get('emr.system_type', 'o19')
-		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_verify', False)
+		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_auto_increment', False)
 		if system_type == 'opro' and verify_document_ids:
 			"""
 			This is to fix the null status in the 'opro' queue_document_link table.

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -105,7 +105,16 @@ def get_o19_documents(self):
 	system_type = self.config.get('emr.document_folder')
 
 	if system_type == 'pending':
-		return self.get_inbox_pendingdocs_documents(self)
+		system_type = self.config.get('emr.system_type', 'o19')
+		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_verify', False)
+		if system_type == 'o19' and verify_document_ids:
+			"""
+			This is to fix the null status in the 'opro' queue_document_link table.
+			It should be removed immediately once the aforementioned issue is resolved.
+			"""
+			return self.get_inbox_pendingdocs_documents_opro(self)
+		else:
+			return self.get_inbox_pendingdocs_documents(self)
 	elif system_type == 'incoming':
 		return self.get_inbox_incomingdocs_documents(self)
 
@@ -137,7 +146,7 @@ def get_inbox_pendingdocs_documents(self):
 			driver.get(f"{self.base_url}/dms/inboxManage.do?method=getDocumentsInQueues")
 		
 		try:
-			driver.implicitly_wait(300)
+			driver.implicitly_wait(115)
 			queuenames_field = driver.find_element(By.ID, "queueNames")
 		except TimeoutException:
 			self.logger.debug("Timeout occurred when loading pending documents.")
@@ -276,3 +285,56 @@ def get_inbox_incomingdocs_documents(self):
 							self.logger.error(f"An error occurred: {file_response.status_code}")
 							return False
 	return False
+
+
+def get_inbox_pendingdocs_documents_opro(self):
+	"""
+    Fetch and process the next pending EMR document from the inbox for opro to resolve null in queue_document_link.
+
+    This method increments the next document number to process based on the last
+    processed file recorded in the configuration. It constructs a request to fetch
+    the document from the DMS, handles retry logic based
+    on configurable limits, and updates the processing state accordingly.
+
+    Returns:
+        bool: True if a document was successfully fetched and ready for processing;
+              False if no documents are left, if an error occurred, or if the document
+              should be skipped after exceeding retry limits.
+    """
+	pending_file = self.config.get('inbox.pending')
+	item = 0
+	if pending_file is None:
+		self.logger.info(f"Pending documents last processed file details missing in configuration.")
+		return False
+	else:
+		last_processed_file = int(pending_file)
+		item = last_processed_file + 1
+
+	max_retries = self.config.get('file_processing.max_retries')  # Get max retry count from configuration
+	current_retries = self.config.get('file_processing.pending_retries')  # Get current retry count from configuration
+	
+	file_url = f"{self.base_url}/dms/ManageDocument.do?method=display&doc_no={item}"
+	self.headers['Referer'] = file_url
+	self.session.headers.update(self.headers)
+	file_response = self.session.get(file_url, verify=self.config.get('emr.verify-HTTPS'), timeout=self.config.get('general_setting.timeout', 300))
+
+	if file_response.status_code == 200 and file_response.content:
+		if max_retries <= current_retries:  # If max retries is equal to current retries
+			self.config.update_pending_retries(0)  # Reset the retry count in the configuration
+			tag_skipped_files = self.config.get('emr.tag_skipped_files')
+			if tag_skipped_files:
+				self.file_name = item
+			else:
+				self.config.update_pending_inbox(item)
+				self.logger.info(f"Max retries exceeded for processing. Skipping document No: {item}.")
+				return False
+		else:
+			self.config.update_pending_retries(current_retries + 1)
+			self.config.set_shared_state('current_file', file_response.content)
+			self.file_name = item
+			self.logger.info(f"Fetched EMR document from Pending Docs...Processing Document No: {item}.")
+			return True
+	else:
+		self.logger.info(f"No more documents to process or error while fetching document {item}.")
+	return False
+

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -107,7 +107,7 @@ def get_o19_documents(self):
 	if system_type == 'pending':
 		system_type = self.config.get('emr.system_type', 'o19')
 		verify_document_ids = self.config.get('emr.opro_pendingdocs_ids_verify', False)
-		if system_type == 'o19' and verify_document_ids:
+		if system_type == 'opro' and verify_document_ids:
 			"""
 			This is to fix the null status in the 'opro' queue_document_link table.
 			It should be removed immediately once the aforementioned issue is resolved.

--- a/src/processors/workflow/emr_workflow.py
+++ b/src/processors/workflow/emr_workflow.py
@@ -97,6 +97,7 @@ class Workflow:
 
         self.headers['Origin'] = self.origin_url
         self.headers['Referer'] = self.base_url
+        self.headers['User-Agent'] = config.get('emr.user_agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36')
 
         self.update_o19 = o19_updater.update_o19
         self.view_output = o19_updater.view_output

--- a/src/processors/workflow/emr_workflow.py
+++ b/src/processors/workflow/emr_workflow.py
@@ -108,6 +108,7 @@ class Workflow:
         self.get_document_processor_type = o19_inbox.get_document_processor_type
         self.get_o19_documents = o19_inbox.get_o19_documents
         self.get_inbox_pendingdocs_documents = o19_inbox.get_inbox_pendingdocs_documents
+        self.get_inbox_pendingdocs_documents_opro = o19_inbox.get_inbox_pendingdocs_documents_opro
         self.get_inbox_incomingdocs_documents = o19_inbox.get_inbox_incomingdocs_documents
         self.get_local_documents = local_files.get_local_documents
         self.has_ocr = ocr.has_ocr


### PR DESCRIPTION
- created a workaround fix for some opro instances where automatically uploaded PDFs (like faxes) are entered in to the EMR without updating the Active/Inactive status of the table queue_document_link
- this fix will retrieve all pending documents and increment the processing by 1 for the document_id

## Summary by Sourcery

Implement a workaround for handling pending documents in the OPRO EMR system to resolve null status issues in document processing

New Features:
- Added a new method to handle pending documents specifically for OPRO system
- Introduced configuration option to enable OPRO-specific document processing

Bug Fixes:
- Fixed null status issue for automatically uploaded PDFs in queue_document_link table
- Implemented retry mechanism for processing pending documents

Enhancements:
- Improved document processing logic with configurable retry limits
- Added more granular logging for document processing

Chores:
- Updated import statements and module configurations
- Modified login and workflow managers to support new document processing method