### PR TITLE
Fix for opro workaround when tagging all incremental pendingdocs document id's

### DIFF
--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -334,6 +334,9 @@ def get_inbox_pendingdocs_documents_opro(self):
 					self.config.update_pending_inbox(item)
 					self.logger.info(f"Document {item} already tagged to patient.")
 					return False
+		else:
+			self.logger.info(f"Unexpected error from server, error code {document_details.status_code}")
+			return False
 
 		if max_retries <= current_retries:  # If max retries is equal to current retries
 			self.config.update_pending_retries(0)  # Reset the retry count in the configuration


### PR DESCRIPTION
When opro_pendingdocs_ids_incremental is set to true, added fix so that only documents that do not have a demographic id are processed. This prevents re-processing of already manually tagged/filed/labelled documents by human MOA.

## Summary by Sourcery

Skip reprocessing of manually tagged OPRO incremental pending documents by checking for an existing demographic ID

Bug Fixes:
- Prevent reprocessing of already tagged or labeled documents in OPRO when incremental pendingdocs IDs are enabled

Enhancements:
- Add HTML fetch and parsing via BeautifulSoup to inspect demographic ID in document details
- Consolidate config flag check for opro_pendingdocs_ids_auto_increment into a single conditional