### PR TITLE
Revision of PIF function, continual function unless stop command or error.

### DIFF
--- a/docs/ocr_api.md
+++ b/docs/ocr_api.md
@@ -140,9 +140,8 @@ openssl req -x509 -newkey rsa:4096 \
   -subj "/CN=localhost"
 ```
 
-To generate a key and certificate, create them and place both files in the `doctr/api/cert` folder, and then
+To generate a key and certificate, create them, place both files in the `doctr/api/cert` folder, and then update the line in `doctr/api/docker-compose.yml` to include the key and certificate.
 
-Update the line (doctr/api/docker-compose.yml) to include the key and certificate
 ```
 command: uvicorn app.main:app --reload --workers 1 --host 0.0.0.0 --port 8080 --ssl-keyfile /app/certs/key.pem --ssl-certfile /app/certs/cert.pem
 ```

--- a/docs/ocr_api.md
+++ b/docs/ocr_api.md
@@ -140,7 +140,7 @@ openssl req -x509 -newkey rsa:4096 \
   -subj "/CN=localhost"
 ```
 
-to generate a key and certificate, create them and place both files in the `doctr/api/cert` folder, and then
+To generate a key and certificate, create them and place both files in the `doctr/api/cert` folder, and then
 
 Update the line (doctr/api/docker-compose.yml) to include the key and certificate
 ```

--- a/docs/pdf-processor-overview.md
+++ b/docs/pdf-processor-overview.md
@@ -33,7 +33,7 @@ In your `config-pdf-processor.yaml` file, use the following fields to configure 
 
 ### `pdf_processor: pdf_tag`
 - **Type**: String  
-- **Description**: Unique tag identifier for AIMOA to find the json from the pdf file. Can be changed to any value to match the tag in the pdf file.  
+- **Description**: Unique tag identifier for AIMOA to find the JSON from the PDF file. Can be changed to any value to match the tag in the PDF file.  
 - **Example**: `pdf_processor: `
 `pdf_tag : '#ai-moa'`
 

--- a/docs/pif-overview.md
+++ b/docs/pif-overview.md
@@ -75,7 +75,7 @@ In your `config-pif.yaml` file, use the following fields to configure AIMOA with
 
 ### `confidential_unattached_id`
 - **Type**: Integer  
-- **Description**: A unique identifier used for creating a tickler notificaitons with AIMOA, should be a demographic number  
+- **Description**: A unique identifier used for creating a tickler notificaitons with AIMOA. This should be a demographic number.
 - **Example**: `100`
 
 ### `error_msg_to`

--- a/docs/pif-overview.md
+++ b/docs/pif-overview.md
@@ -83,6 +83,16 @@ In your `config-pif.yaml` file, use the following fields to configure AIMOA with
 - **Description**: The identifier to whom error messages are sent when an issue occurs during PIF processing.  
 - **Example**: `999998`
 
+### `error_tickler_max_count`
+- **Type**: Integer  
+- **Description**: Maximum error count for stopping PIF processing
+- **Example**: `5`
+
+### `notify_row_count`
+- **Type**: Integer  
+- **Description**: Limit after which a notification is sent
+- **Example**: `50`
+
 ### `exception_provider`
 - **Type**: List of Strings  
 - **Description**: A list of healthcare providers who are exceptions and should be treated differently when processing PIF records. Each entry in the list typically represents a combination of a provider's last name and first name.  
@@ -121,6 +131,35 @@ In your `config-pif.yaml` file, use the following fields to configure AIMOA with
 - **Type**: Integer  
 - **Description**: The port number used to connect to the database.  
 - **Example**: `3306`
+
+The above configuration applies when AIMOA is installed in the same environment as the PIF database.
+If the PIF database is hosted in a different environment, it is recommended to use SSL for the database connection.
+To enable this, use the following fields (pif_db_encrypt, ssl_ca,ssl_cert, ssl_key, ssl_verify_cert).
+
+### `pif_db_encrypt`
+- **Type**: Boolean  
+- **Description**: Enable SSL for the database connection.
+- **Example**: `false`
+
+### `ssl_ca`
+- **Type**: String  
+- **Description**: Path to the ca.pem file.  
+- **Example**: `./ca.pem`
+
+### `ssl_cert`
+- **Type**: String  
+- **Description**: Path to the client-cert.pem file.  
+- **Example**: `./client-cert.pem`
+
+### `ssl_key`
+- **Type**: String  
+- **Description**: Path to the client-key.pem file.  
+- **Example**: `./client-key.pem`
+
+### `ssl_verify_cert`
+- **Type**: Boolean  
+- **Description**: To verify SSL for the database connection.
+- **Example**: `true`
 
 ### `primary_fsa_mrp_id`
 - **Type**: Integer  
@@ -177,23 +216,36 @@ In your `config-pif.yaml` file, use the following fields to configure AIMOA with
 
 ## Using AIMOA for PIF
 
-You can configure AIMOA to process PIF at any time interval, but the recommended interval is every 5 or 10 minutes. 
-**Even if the cron starts the process, processing of PIF is controlled using ticklers**. 
+You can configure AIMOA to process PIF at any time interval, but the recommended interval is every 20 or 30 minutes. 
+
 #### The basic commands for using PIF with ticklers are listed below.
 
-For this, use site_name and aimee_uid in `config-pif.yaml` so that AIMOA can view the control messages. AIMOA will only process the start commands for the current day.
+For this, use site_name and aimee_uid in `config-pif.yaml` so that AIMOA can view the control messages.
 
 **Control tickler message format:**
 
-```start:pif;start_from:250;batch_size:5;skip_ids:250```
+Eg 1:
+```config:pif; skip_ids:250,258,260```
+Eg 2:
+```config:pif; skip_from:85; skip_to:200;```
+Eg 3:
+```stop:pif;```
+Eg 4:
+```aimoa:pif-status;```
 
-**start: pif;** Only if this message is present will AIMOA start processing. **Required (Mandatory).**
+**stop: pif;** Only if this message is present will AIMOA stop processing. **Remove to continue processing.** AIMOA will generate this to stop further processing if the error count exceeds the limit specified by `error_tickler_max_count`
 
-**start_from: 250;** Will start processing documents from ID 250. Not mandatory, but recommended to have.
-
-**batch_size: 5;** Batch size to be processed. Not mandatory, but recommended to have.
+**skip_from: 85; skip_to:200;** Will skip processing documents from ID 85 to 200. Not mandatory.
 
 **skip_ids: 250, 251;** Will skip documents with IDs 250 and 251 when used. Not mandatory, use only when required."
+
+**aimoa:pif-status;** AIMOA provides information about the last processed PIF documents. Not mandatory, use only when required."
+
+## Example
+**aimoa:pif-status;**
+```
+Started task at 2026-01-10 13:56:12;Completed task at 2026-01-10 13:56:28;Processed 3 files during execution.
+```
 
 ## Common Error Notifications
 

--- a/docs/pif-overview.md
+++ b/docs/pif-overview.md
@@ -237,9 +237,9 @@ Eg 4:
 
 **skip_from: 85; skip_to:200;** Will skip processing documents from ID 85 to 200. Not mandatory.
 
-**skip_ids: 250, 251;** Will skip documents with IDs 250 and 251 when used. Not mandatory, use only when required."
+**skip_ids: 250, 251;** Will skip documents with IDs 250 and 251 when used. Not mandatory, use only when required.
 
-**aimoa:pif-status;** AIMOA provides information about the last processed PIF documents. Not mandatory, use only when required."
+**aimoa:pif-status;** AIMOA provides information about the last processed PIF documents. Not mandatory, use only when required.
 
 ## Example
 **aimoa:pif-status;**

--- a/src/config-pif.yaml.example
+++ b/src/config-pif.yaml.example
@@ -60,6 +60,10 @@ pif:
 
   last_processed: 0 # Keeps track of the last processed PIF record ID. This is useful for continuing processing from where it was last left off in case of an interruption.
 
+  error_tickler_max_count: 5 # Maximum error count for stopping PIF processing
+
+  notify_row_count: 50 # Limit after which a notification is sent
+
   database: test_db # The name of the database used for storing and retrieving patient data for PIF processing.
 
   table_name: your_table_name # The name of the table in the database where PIF records are stored.
@@ -70,6 +74,15 @@ pif:
   password: your_password # The password associated with the username for authenticating against the database.
 
   port: 3306 # The port number used to connect to the database.
+
+  # The above configuration applies when AIMOA is installed in the same environment as the PIF database. If the PIF database is hosted in a different environment, it is recommended to use SSL for the database connection. To enable this, use the following fields (pif_db_encrypt, ssl_ca,ssl_cert, ssl_key, ssl_verify_cert)
+
+  pif_db_encrypt: true # Enable SSL for the database connection.
+  ssl_ca: './ca.pem' # Path to the ca.pem file.
+  ssl_cert: './client-cert.pem' # Path to the client-cert.pem file.
+  ssl_key: './client-key.pem' # Path to the client-cert.pem file.
+  ssl_verify_cert: 'true' # To verify SSL for the database connection.
+
 
   error_msg_to: 999998 # The identifier to whom error messages are sent when an issue occurs during PIF processing.
 

--- a/src/processors/utils/__init__.py
+++ b/src/processors/utils/__init__.py
@@ -25,4 +25,4 @@ from .llm import query_prompt
 from .pif import query_pif, get_fht_tickler_config, update_fht_tickler_config, get_postal_code_category, new_patient_details, update_patient_details, search_patient, create_tickler, fill_element
 from .pdf_processor import pif_pdf
 
-__all__ = ['get_local_documents' , 'has_ocr', 'extract_text_from_pdf_file', 'extract_text_doctr', 'extract_text_doctr_api', 'query_prompt', 'query_pif', 'get_postal_code_category', 'new_patient_details', 'update_patient_details', 'search_patient', 'create_tickler', 'get_fht_tickler_config', 'update_fht_tickler_config', 'fill_element', 'pif_pdf']
+__all__ = ['get_local_documents' , 'has_ocr', 'extract_text_from_pdf_file', 'extract_text_doctr', 'extract_text_doctr_api', 'query_prompt', 'query_pif','get_aimoa_status_report', 'get_lines_after_last_match', 'get_postal_code_category', 'new_patient_details', 'update_patient_details', 'search_patient', 'create_tickler', 'get_fht_tickler_config', 'update_fht_tickler_config', 'fill_element', 'pif_pdf']

--- a/src/processors/utils/pif.py
+++ b/src/processors/utils/pif.py
@@ -459,7 +459,7 @@ def get_fht_tickler_config(self, assigned_to):
             if update_status:
                 self.logger.info(f"PIF status reporting.")
                 tickler_message = self.get_aimoa_status_report(self,query='query_pif')
-                self.update_fht_tickler_config(self, tickler_id, tickler_message)
+                self.update_fht_tickler_config(self, update_status_tickler_id, tickler_message)
 
             if stop_status:
                 self.logger.info(f"Stop tickler found; processing has been stopped.")

--- a/src/processors/utils/pif.py
+++ b/src/processors/utils/pif.py
@@ -20,6 +20,7 @@
 # ***
 
 import re
+import os
 from datetime import datetime
 from bs4 import BeautifulSoup
 import mysql.connector
@@ -100,17 +101,22 @@ def query_pif(self):
         starting_fht_id = last_processed_fht_id
         current_row = None
         processed_fht_count = 0
+        self.error_tickler_count = self.config.get('pif.error_tickler_count', 0)
+        notify_row_count = self.config.get('pif.notify_row_count', 50)
+        last_processed_fht_count = self.config.get('pif.processed_fht_count', 0)
         fht_batch_size = self.config.get('pif.batch_size', 1)
         fht_tickler_id = 0
         skip_ids = []
+        skip_from_to = []
         start_processing, fht_tickler_id, fht_tickler_data = self.get_fht_tickler_config(self, str(assigned_to))
 
         if not start_processing:
             return True
 
-        if 'start_from' in fht_tickler_data:
-            last_processed_fht_id = fht_tickler_data['start_from']
-            starting_fht_id = last_processed_fht_id
+        # Remove; will cause infinite loop
+        # if 'start_from' in fht_tickler_data:
+        #     last_processed_fht_id = fht_tickler_data['start_from']
+        #     starting_fht_id = last_processed_fht_id
 
         if 'batch_size' in fht_tickler_data:
             fht_batch_size = fht_tickler_data['batch_size']
@@ -118,16 +124,36 @@ def query_pif(self):
         if 'skip_ids' in fht_tickler_data:
             skip_ids = fht_tickler_data['skip_ids']
 
+        if 'skip_from' in fht_tickler_data and 'skip_to' in fht_tickler_data:
+            from_id = fht_tickler_data['skip_from']
+            to_id = fht_tickler_data['skip_to']
+            skip_from_to = list(range(from_id, to_id + 1))
+
         self.logger.info("Creating connection for PIF.")
 
         # Establish connection to the MySQL server
-        connection = mysql.connector.connect(
-            host=self.config.get('pif.host'),
-            user=self.config.get('pif.username'),
-            password=self.config.get('pif.password'),
-            database=self.config.get('pif.database'),
-            port=self.config.get('pif.port')
-        )
+        pif_db_encrypt = self.config.get('pif.pif_db_encrypt', False)
+
+        if pif_db_encrypt:
+            connection = mysql.connector.connect(
+                host=self.config.get('pif.host'),
+                user=self.config.get('pif.username'),
+                password=self.config.get('pif.password'),
+                database=self.config.get('pif.database'),
+                port=self.config.get('pif.port'),
+                ssl_ca=self.config.get('pif.ssl_ca'),
+                ssl_cert=self.config.get('pif.ssl_cert'),
+                ssl_key=self.config.get('pif.ssl_key'),
+                ssl_verify_cert=self.config.get('pif.ssl_verify_cert', True)
+            )
+        else:
+            connection = mysql.connector.connect(
+                host=self.config.get('pif.host'),
+                user=self.config.get('pif.username'),
+                password=self.config.get('pif.password'),
+                database=self.config.get('pif.database'),
+                port=self.config.get('pif.port')
+            )
 
         table_name = self.config.get('pif.table_name')
 
@@ -157,6 +183,26 @@ def query_pif(self):
         for row in results:
 
             if processed_fht_count < fht_batch_size:
+
+                self.error_tickler_count = self.config.get('pif.error_tickler_count', 0)
+
+                if self.error_tickler_count >= self.config.get('pif.error_tickler_max_count', 3):
+                    if last_processed_fht_id == self.config.get('pif.last_processed', 0):
+                        last_processed_fht_id -= 1
+                    message = f"stop:pif;"
+                    unattached_patient_id = self.config.get('pif.confidential_unattached_id')
+                    self.create_tickler(self, str(unattached_patient_id), message, str(assigned_to))
+
+                    to = self.config.get('pif.error_msg_to')
+                    message = f"Maximum error count reached, stopping processing. Last processed id {last_processed_fht_id}"
+                    self.create_tickler(self, str(unattached_patient_id), message, str(to))
+                    self.logger.info("Maximum error count reached for PIF.")
+
+                    self.error_tickler_count = 0
+                    self.config.config['pif']['error_tickler_count'] = self.error_tickler_count
+                    self.config.save_config()
+
+                    break
                 
                 last_processed_fht_id = row['id']
 
@@ -165,12 +211,12 @@ def query_pif(self):
                 self.logger.info(f"Started processing PIF Id : {row['id']}")
 
                 if not isinstance(skip_ids, list):
-                    if row['id'] == skip_ids:
+                    if row['id'] == skip_ids or (skip_from_to and row['id'] in skip_from_to):
                         self.logger.info(f"Skipping PIF Id : {row['id']}")
                         processed_fht_count += 1
                         continue
 
-                elif row['id'] in skip_ids:
+                elif row['id'] in skip_ids or (skip_from_to and row['id'] in skip_from_to):
                     self.logger.info(f"Skipping PIF Id : {row['id']}")
                     processed_fht_count += 1
                     continue
@@ -242,6 +288,10 @@ def query_pif(self):
         to = self.config.get('pif.error_msg_to')
         unattached_patient_id = self.config.get('pif.confidential_unattached_id')
         self.create_tickler(self, str(unattached_patient_id), message, str(to))
+
+        self.error_tickler_count += 1
+        self.config.config['pif']['error_tickler_count'] = self.error_tickler_count
+        self.config.save_config()
     
     finally:
         # Ensure that the connection is closed properly
@@ -250,15 +300,31 @@ def query_pif(self):
             connection.close()
             self.logger.info("PIF connection closed.")
 
+        if int(processed_fht_count) + int(last_processed_fht_count) >= int(notify_row_count):
+            self.config.config['pif']['processed_fht_count'] = (int(processed_fht_count) + int(last_processed_fht_count)) % int(notify_row_count)
+            self.config.save_config()
+
+            times_count = (int(processed_fht_count) + int(last_processed_fht_count)) // int(notify_row_count)
+            times_count = times_count * notify_row_count
+
+            message = f"Completed processing batch of {times_count} documents, Last processed PIF Id : {last_processed_fht_id};"
+            to = self.config.get('pif.error_msg_to')
+            unattached_patient_id = self.config.get('pif.confidential_unattached_id')
+            self.create_tickler(self, str(unattached_patient_id), message, str(to))
+        else:
+            self.config.config['pif']['processed_fht_count'] = (int(processed_fht_count) + int(last_processed_fht_count))
+            self.config.save_config()
+
         if start_processing:
-            self.update_fht_tickler_config(self, fht_tickler_id, processed_fht_count, last_processed_fht_id, starting_fht_id)
+            # Removed since auto-start will be used going forward
+            # self.update_fht_tickler_config(self, fht_tickler_id, tickler_message)
             if results:
                 self.config.config['pif']['last_processed'] = last_processed_fht_id + 1
                 self.config.save_config()
 
         return True
 
-def update_fht_tickler_config(self, fht_tickler_id, processed_fht_count, last_processed_fht_id, starting_fht_id):
+def update_fht_tickler_config(self, fht_tickler_id, tickler_message):
     """
     Updates the control tickler configuration by submitting progress information to the EMR.
 
@@ -286,7 +352,7 @@ def update_fht_tickler_config(self, fht_tickler_id, processed_fht_count, last_pr
         driver.get(f"{self.base_url}/tickler/ticklerEdit.jsp?tickler_no={fht_tickler_id}")
         driver.implicitly_wait(20)
         message_element = driver.find_element(By.NAME, 'newMessage')
-        message_element.send_keys('Starting PIF Id: '+ str(starting_fht_id) +', Processed up to PIF Id : ' + str(last_processed_fht_id) + ', Processed file count : ' + str(processed_fht_count))
+        message_element.send_keys(str(tickler_message))
 
         statusSelect = Select(driver.find_element(By.NAME, "status"))
         statusSelect.select_by_value("C")
@@ -309,16 +375,16 @@ def get_fht_tickler_config(self, assigned_to):
     - The tickler ID.
     - A dictionary containing the tickler data.
 
-    If the tickler data includes a 'start' key with the value 'pif', the method returns 
+    If the tickler data includes a 'stop' key with the value 'pif', the method returns 
     the tickler ID and its associated data. If no valid tickler is found, it returns 
-    `False`, `0`, and `0`.
+    `True`, `0`, and `0`.
 
     Parameters:
         assigned_to (str): The user ID to filter the ticklers assigned to that user.
 
     Returns:
         tuple: A tuple where:
-            - A boolean indicating if a valid tickler was found (`True` or `False`).
+            - An inverse boolean indicating if a valid tickler was found (`False` or `True`).
             - The tickler ID (if found).
             - A dictionary with the tickler data if found, otherwise `0`.
     """
@@ -328,17 +394,33 @@ def get_fht_tickler_config(self, assigned_to):
 
         formatted_date = current_date.strftime('%Y-%m-%d')
 
+        year = current_date.year
+        month = current_date.month - 1
+
+        if month == 0:
+            month = 12
+            year -= 1
+
+        old_formatted_date = current_date.replace(year=year, month=month).strftime('%Y-%m-%d')
+
         driver = self.driver
-        driver.get(f"{self.base_url}/tickler/ticklerMain.jsp?ticklerview=A&assignedTo={assigned_to}&xml_vdate={formatted_date}&xml_appointment_date={formatted_date}")
+        driver.get(f"{self.base_url}/tickler/ticklerMain.jsp?ticklerview=A&assignedTo={assigned_to}&xml_vdate={old_formatted_date}&xml_appointment_date={formatted_date}")
         driver.implicitly_wait(10)
 
         try:
             table = driver.find_element(By.ID, 'ticklersTbl')
             tbody = table.find_element(By.TAG_NAME, 'tbody')
             rows = tbody.find_elements(By.TAG_NAME, 'tr')
+            tickler_data = {}
+            update_status = False
+            update_status_tickler_id = 0
+            stop_status = False
             for row in rows:
                 td = row.find_elements(By.TAG_NAME, 'td')
-                checkbox = row.find_element(By.NAME, 'checkbox')
+                try:
+                    checkbox = row.find_element(By.NAME, 'checkbox')
+                except NoSuchElementException as e:
+                    continue
                 tickler_id = checkbox.get_attribute("value")
 
                 s = td[9].text.lower()
@@ -364,13 +446,113 @@ def get_fht_tickler_config(self, assigned_to):
                     else:
                         data[p] = True
 
-                if 'start' in data and data['start'] == 'pif':
-                    return True, tickler_id, data
+                if 'aimoa' in data and data['aimoa'] == 'pif-status':
+                    update_status = True
+                    update_status_tickler_id = tickler_id                    
 
-            return False, 0, 0
+                if 'stop' in data and data['stop'] == 'pif':
+                    stop_status = True
+
+                if 'config' in data and data['config'] == 'pif':
+                    tickler_data = data
+
+            if update_status:
+                self.logger.info(f"PIF status reporting.")
+                tickler_message = self.get_aimoa_status_report(self,query='query_pif')
+                self.update_fht_tickler_config(self, tickler_id, tickler_message)
+
+            if stop_status:
+                self.logger.info(f"Stop tickler found; processing has been stopped.")
+                return False, 0, 0
+
+            return True, 0, tickler_data
 
         except Exception as e:
+            self.logger.error(f"An unexpected error occurred when checking tickler: {e}")
             return False, 0, 0
+
+def get_aimoa_status_report(self, query):
+    log_file = self.config.get('logging.filename', 'workflow.log')
+    query = 'Executing task: ' + query
+    lines = self.get_lines_after_last_match(self, log_file, query)
+
+    processing_count = 0
+    message = ''
+    for line in lines:
+        if query in line:
+            log_time = line.split(",")[0]
+            message = message + f'Started task at {log_time};'
+
+        if "Started processing PIF Id" in line:
+            processing_count += 1
+
+        if "Stop tickler found" in line:
+            message = message + f'Stop tickler found;'
+
+        if "Maximum error count reached for PIF" in line:
+            message = message + f'Error count reached maximum limit;'
+
+        if "Workflow execution completed" in line:
+            log_time = line.split(",")[0]
+            message = message + f'Completed task at {log_time};'
+            message = message + f'Processed {processing_count} files during execution.'
+            break
+
+    return message
+
+def get_lines_after_last_match(self, filepath, phrase, block_size=4096):
+
+    phrase_b = phrase.encode()
+
+    with open(filepath, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        pos = f.tell()  # start from EOF
+
+        buffer = b""
+        match_positions = []
+
+        block_count = 0
+
+        # Scan backwards until we find two matches
+        while pos > 0 and len(match_positions) < 2:
+            block_count += 1
+            read_size = min(block_size, pos)
+            pos -= read_size
+            f.seek(pos)
+
+            chunk = f.read(read_size)
+            buffer = chunk + buffer
+
+            lines = buffer.split(b"\n")
+
+            # save possibly partial first line for next block
+            buffer = lines[0]
+
+            # absolute byte offset of the first full line in this block
+            line_pos = pos + len(buffer) + 1
+
+            # scan lines forward (so offsets are correct)
+            for line in lines[1:]:
+                if phrase_b in line:
+                    match_positions.append(line_pos)
+                    if len(match_positions) == 2:
+                        break
+                line_pos += len(line) + 1
+
+        # if less than 2 matches, return empty
+        if len(match_positions) < 2:
+            return []
+
+        if block_count == 1:
+            second_last_pos = match_positions[0]
+        else:
+            # second-to-last match offset
+            second_last_pos = match_positions[1]
+
+        # read from second-to-last match to EOF
+        f.seek(second_last_pos)
+        return f.read().decode(errors="ignore").splitlines()
+
 
 def search_patient(self, data, row, match_mode):
     """
@@ -549,6 +731,9 @@ def new_patient_details(self, row, category):
             to = self.config.get('pif.error_msg_to')
             unattached_patient_id = self.config.get('pif.confidential_unattached_id')
             self.create_tickler(self, str(unattached_patient_id), message, str(to))
+            self.error_tickler_count += 1
+            self.config.config['pif']['error_tickler_count'] = self.error_tickler_count
+            self.config.save_config()
             return
 
         try:
@@ -562,6 +747,9 @@ def new_patient_details(self, row, category):
             to = self.config.get('pif.error_msg_to')
             unattached_patient_id = self.config.get('pif.confidential_unattached_id')
             self.create_tickler(self, str(unattached_patient_id), message, str(to))
+            self.error_tickler_count += 1
+            self.config.config['pif']['error_tickler_count'] = self.error_tickler_count
+            self.config.save_config()
             return
 
         demographic_href = form_submit_element.get_attribute("href")
@@ -679,6 +867,12 @@ def update_patient_details(self, row, demographic_id, category, is_patient=False
                 to = self.config.get('pif.error_msg_to')
                 self.create_tickler(self, demographic_id, message, str(to))
 
+            else:
+                # Sucessfully created, re-setting error count to zero
+                self.error_tickler_count = 0
+                self.config.config['pif']['error_tickler_count'] = self.error_tickler_count
+                self.config.save_config()
+
             if category == "secondary_fsa":
                 message = self.config.get('pif.secondary_fsa_message')
                 to = self.config.get('pif.secondary_fsa_msg_to')
@@ -687,6 +881,8 @@ def update_patient_details(self, row, demographic_id, category, is_patient=False
         if is_patient:
             residentSelect = Select(driver.find_element(By.ID, "resident"))
             selected_text = residentSelect.first_selected_option.text
+
+            selected_value = residentSelect.first_selected_option.get_attribute("value")
 
             if not selected_text.strip():
                 if category == "primary_fsa":
@@ -707,7 +903,7 @@ def update_patient_details(self, row, demographic_id, category, is_patient=False
                     message = self.config.get('pif.secondary_fsa_message')
                     to = self.config.get('pif.secondary_fsa_msg_to')
                     self.create_tickler(self, demographic_id, message, str(to))
-            else:
+            elif str(selected_value) != str(self.config.get('pif.primary_fsa_resident_id')):
                 message = f"Patient is eligible, check patient's internal providers information."
                 to = self.config.get('pif.error_msg_to')
                 self.create_tickler(self, demographic_id, message, str(to))

--- a/src/processors/utils/pif.py
+++ b/src/processors/utils/pif.py
@@ -94,7 +94,7 @@ def query_pif(self):
     """
     try:
 
-        connection = None
+        results = connection = None
         assigned_to = self.config.get('pif.aimee_uid')
         start_processing = False
         last_processed_fht_id = self.config.get('pif.last_processed', 0)

--- a/src/processors/workflow/emr_workflow.py
+++ b/src/processors/workflow/emr_workflow.py
@@ -123,12 +123,15 @@ class Workflow:
         self.pif_pdf = pdf_processor.pif_pdf
         self.get_fht_tickler_config = pif.get_fht_tickler_config
         self.update_fht_tickler_config = pif.update_fht_tickler_config
+        self.get_aimoa_status_report = pif.get_aimoa_status_report
+        self.get_lines_after_last_match = pif.get_lines_after_last_match
         self.get_postal_code_category = pif.get_postal_code_category
         self.new_patient_details = pif.new_patient_details
         self.update_patient_details = pif.update_patient_details
         self.search_patient = pif.search_patient
         self.create_tickler = pif.create_tickler
         self.fill_element = pif.fill_element
+        self.error_tickler_count = 0
         self.get_category_types = document_category.get_category_types
         self.get_category_type = document_category.get_category_type
         self.get_document_description = document_category.get_document_description


### PR DESCRIPTION
Revised the function of PIF so AI-MOA processes continually unless given a stop command in Ticklers, or faces consecutive errors or stalls on repeated tries on an particular entry. It will also notify regular processing updates. Updated some documentation grammar and spelling.

## Summary by Sourcery

Make PIF processing continuous with tickler-based stop control, enhanced error handling, and periodic status notifications, along with SSL DB support and documentation updates.

New Features:
- Allow PIF processing to be controlled via stop/config/status ticklers instead of start commands, including range-based skip controls.
- Introduce AIMOA status reporting for recent PIF workflow activity via ticklers.
- Add optional SSL configuration for connecting to the PIF MySQL database.

Bug Fixes:
- Prevent potential infinite-loop behavior related to reusing a tickler start_from value.
- Ensure error counters are reset on successful patient detail updates and incremented on failures.

Enhancements:
- Implement error-count tracking that stops PIF processing and auto-creates stop and alert ticklers when a configurable threshold is reached.
- Send periodic notification ticklers after processing a configurable number of PIF records.
- Extend tickler parsing to scan a wider date range and handle rows without checkboxes more robustly.
- Export new PIF utility helpers through the workflow and utils modules for reuse.

Documentation:
- Update PIF usage docs to describe new stop/config/status ticklers, error and notification configuration, and SSL connection options.
- Correct grammar, capitalization, and clarity in OCR and PDF processor documentation.