### PR TITLE
Skip processing if errors exceed a limit

### DIFF
--- a/docs/pif-overview.md
+++ b/docs/pif-overview.md
@@ -268,3 +268,10 @@ The above notification occurs when a patient registers for primary FSA but is on
 The system will also send a notification if the postal code is invalid.
 
 
+## When PIF stops completely
+
+```
+Sample: Unexpected error. Please contact the system administrator. Last processed ID: 123.
+```
+If this message appears in the tickler, reset error_tickler_count in the config file to 0 and set stop_flag to false once the underlying issue has been resolved.
+

--- a/src/config-pif.yaml.example
+++ b/src/config-pif.yaml.example
@@ -62,6 +62,10 @@ pif:
 
   error_tickler_max_count: 5 # Maximum error count for stopping PIF processing
 
+  error_tickler_count: 0 # Used to track the error count while processing documents. Set this to zero to restart processing once the error count exceeds 10 and further processing has stopped.
+  
+  stop_flag: false # Set this to false when error_tickler_count is within the limit of 10. When error_tickler_count exceeds 10, this value will be set to true.
+
   notify_row_count: 50 # Limit after which a notification is sent
 
   database: test_db # The name of the database used for storing and retrieving patient data for PIF processing.

--- a/src/processors/utils/pif.py
+++ b/src/processors/utils/pif.py
@@ -109,7 +109,11 @@ def query_pif(self):
         skip_ids = []
         skip_from_to = []
 
-        # Skip processing if unknown errors exceed a limit of 10.
+        # NOTE:
+        # If error_tickler_count reaches 10, PIF processing is intentionally paused
+        # until the error count is manually reset (error_tickler_count,
+        # stop_flag) in the config file.
+        
         if self.error_tickler_count >= 10:
             if not self.config.get('pif.stop_flag', False):
                 to = self.config.get('pif.error_msg_to')

--- a/src/processors/utils/pif.py
+++ b/src/processors/utils/pif.py
@@ -21,7 +21,7 @@
 
 import re
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from bs4 import BeautifulSoup
 import mysql.connector
 from selenium.webdriver.common.by import By
@@ -108,6 +108,20 @@ def query_pif(self):
         fht_tickler_id = 0
         skip_ids = []
         skip_from_to = []
+
+        # Skip processing if unknown errors exceed a limit of 10.
+        if self.error_tickler_count >= 10:
+            if not self.config.get('pif.stop_flag', False):
+                to = self.config.get('pif.error_msg_to')
+                unattached_patient_id = self.config.get('pif.confidential_unattached_id')
+                message = f"Unexpected error; Please contact system admin. Last processed id {last_processed_fht_id}"
+                self.create_tickler(self, str(unattached_patient_id), message, str(to))
+                self.logger.info("Unexpected error; force stopping PIF.")
+                self.config.config['pif']['stop_flag'] = True
+                self.config.save_config()
+            return True
+
+
         start_processing, fht_tickler_id, fht_tickler_data = self.get_fht_tickler_config(self, str(assigned_to))
 
         if not start_processing:
@@ -398,17 +412,10 @@ def get_fht_tickler_config(self, assigned_to):
 
     if self.login_successful:
         current_date = datetime.now()
-
         formatted_date = current_date.strftime('%Y-%m-%d')
 
-        year = current_date.year
-        month = current_date.month - 1
-
-        if month == 0:
-            month = 12
-            year -= 1
-
-        old_formatted_date = current_date.replace(year=year, month=month).strftime('%Y-%m-%d')
+        old_date = current_date - timedelta(days=7)
+        old_formatted_date = old_date.strftime('%Y-%m-%d')
 
         driver = self.driver
         driver.get(f"{self.base_url}/tickler/ticklerMain.jsp?ticklerview=A&assignedTo={assigned_to}&xml_vdate={old_formatted_date}&xml_appointment_date={formatted_date}")
@@ -903,6 +910,7 @@ def update_patient_details(self, row, demographic_id, category, is_patient=False
                 # Successfully created, re-setting error count to zero
                 self.error_tickler_count = 0
                 self.config.config['pif']['error_tickler_count'] = self.error_tickler_count
+                self.config.config['pif']['stop_flag'] = False
                 self.config.save_config()
 
             if category == "secondary_fsa":

--- a/src/processors/utils/pif.py
+++ b/src/processors/utils/pif.py
@@ -116,7 +116,7 @@ def query_pif(self):
                 unattached_patient_id = self.config.get('pif.confidential_unattached_id')
                 message = f"Unexpected error; Please contact system admin. Last processed id {last_processed_fht_id}"
                 self.create_tickler(self, str(unattached_patient_id), message, str(to))
-                self.logger.info("Unexpected error; force stopping PIF.")
+                self.logger.error("Unexpected error; force stopping PIF.")
                 self.config.config['pif']['stop_flag'] = True
                 self.config.save_config()
             return True


### PR DESCRIPTION
Fix a endless loop of errors.

## Summary by Sourcery

Introduce a safeguard to stop PIF processing after repeated unexpected errors and adjust tickler query date handling.

Bug Fixes:
- Prevent endless error loops in PIF processing by stopping processing once unknown errors exceed a configured threshold and recording a stop flag.

Enhancements:
- Change the FHT tickler query window to use the last seven days instead of a previous-month calculation.
- Reset the PIF processing stop flag when a tickler is successfully created so processing can resume.