### PR TITLE
Option to change encryption key or maintain; Default document processor as emr

### DIFF
--- a/docs/ocr_api.md
+++ b/docs/ocr_api.md
@@ -89,8 +89,8 @@ See config.yaml.example for configuring OCR API parameters.
 ```yaml
 ocr:
   api_uri: https://localhost:8002/ocr
-  det_arch: db_resnet50
-  reco_arch: vitstr_base
+  det_arch: fast_base
+  reco_arch: crnn_vgg16_bn
 ```
 
 Edit 'workflow-config.yaml', and use 'extract_text_doctr_api' instead of 'extract_text_doctr' to use the OCR API endpoint.

--- a/src/config-incomingfax.yaml.example
+++ b/src/config-incomingfax.yaml.example
@@ -52,7 +52,7 @@ emr:
   pin: '123'  # PIN for EMR login.
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   tag_skipped_files: true # If set to True, the system will tag the document to the default_unidentified_patient when it reaches the maximum retries and skip the file.
-  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' # Set user-agent
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.101 Safari/537.36' # Set user-agent
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/config-incomingfile.yaml.example
+++ b/src/config-incomingfile.yaml.example
@@ -52,7 +52,7 @@ emr:
   pin: '123'  # PIN for EMR login.
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   tag_skipped_files: true # If set to True, the system will tag the document to the default_unidentified_patient when it reaches the maximum retries and skip the file.
-  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' # Set user-agent
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.101 Safari/537.36' # Set user-agent
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/config-pdf-processor.yaml.example
+++ b/src/config-pdf-processor.yaml.example
@@ -52,7 +52,7 @@ emr:
   pin: '123'  # PIN for EMR login.
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   tag_skipped_files: true # If set to True, the system will tag the document to the default_unidentified_patient when it reaches the maximum retries and skip the file.
-  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' # Set user-agent
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.101 Safari/537.36' # Set user-agent
 
 # PDF Text Processor Tag for JSON Identification
 pdf_processor:

--- a/src/config-pif.yaml.example
+++ b/src/config-pif.yaml.example
@@ -36,7 +36,7 @@ emr:
   password: 'passpwd'  # Password for EMR login.
   pin: '123'  # PIN for EMR login.
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
-  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' # Set user-agent
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.101 Safari/537.36' # Set user-agent
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/config.yaml.example
+++ b/src/config.yaml.example
@@ -53,7 +53,7 @@ emr:
   login_pin_field: true # If set to true, the system will assume that there is a PIN field on the login page. Set this to false if there is no PIN field on the login page.
   opro_pendingdocs_ids_auto_increment: false # Set to True to fetch all pending documents from opro, not just Active pending docs; this will retrieve documents by incrementing the pending document ID by 1.
   tag_skipped_files: true # If set to True, the system will tag the document to the default patient when it reaches the maximum retries and skip the file.
-  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36' # Set user-agent
+  user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.101 Safari/537.36' # Set user-agent
 
 general_setting:
   timeout: 300 # Timeout in seconds for request (POST and GET) to avoid indefinitely hanging requests.

--- a/src/main.py
+++ b/src/main.py
@@ -113,7 +113,7 @@ def encrypt_emr_credentials(config_file: str, workflow_config_file: str) -> None
     config_manager.config["emr"]["username"] = fernet.encrypt(username.encode()).decode()
     config_manager.config["emr"]["password"] = fernet.encrypt(password.encode()).decode()
 
-    if pin and use_pin in ("y", "yes"):
+    if pin:
         config_manager.config["emr"]["pin"] = fernet.encrypt(pin.encode()).decode()
 
     config_manager.save_config()

--- a/src/main.py
+++ b/src/main.py
@@ -214,6 +214,7 @@ def aimoa_fernet_key(env_var: str, system_label: str) -> tuple[bytes, bool]:
             key = Fernet.generate_key()
             regenerated = True
         else:
+            print("Using existing key...\n")
             key = key_str.encode()
 
     return key, regenerated

--- a/src/main.py
+++ b/src/main.py
@@ -94,34 +94,13 @@ def encrypt_emr_credentials(config_file: str, workflow_config_file: str) -> None
     logger.info(f"Encrypting EMR credentials...")
     config_manager: ConfigManager = ConfigManager(config_file, workflow_config_file)
 
-    key = os.getenv("EMR_SECRET_KEY")
-
-    generate_key_flag = 'yes'
-
-    if not key:
-        print("No existing key found. Generating a new one...")
-        key = Fernet.generate_key()
-    else:
-        print("\nIMPORTANT: If you are using the same environment for multiple (document tagging) instances,\n"
-        "generating a new key will make your other instances unable to authenticate with the old key,\n"
-        "and you will have to regenerate credential encryption for those instances.\n")
-
-        generate_key_flag = input(
-            "Enter 'Yes' to generate new key, 'No' to use the existing key: "
-        ).strip().lower()
-
-        if generate_key_flag == "yes":
-            print("Generating a new key...\n")
-            key = Fernet.generate_key()
-        else:
-            key = key.encode()
-
+    key, regenerated = aimoa_fernet_key("EMR_SECRET_KEY", "document tagging")
     fernet = Fernet(key)
 
     username = input("Enter EMR username: ").strip()
     password = prompt_with_confirmation("Enter EMR password:")
 
-    use_pin = input("Does your EMR uses PIN at login? (y/n): ").strip().lower()
+    use_pin = input("Does your EMR use a PIN at login? (y/n): ").strip().lower()
     pin = None
     if use_pin in ("y", "yes"):
         pin = prompt_with_confirmation("Enter EMR PIN: ")
@@ -139,7 +118,7 @@ def encrypt_emr_credentials(config_file: str, workflow_config_file: str) -> None
 
     config_manager.save_config()
 
-    if generate_key_flag == "yes":
+    if regenerated:
         print("\n=== IMPORTANT ===")
         print("For AIMOA to work properly, please store this key securely as an environment variable using the following:\n")
         print(f'export EMR_SECRET_KEY="{key.decode()}"')
@@ -179,28 +158,7 @@ def encrypt_pif_credentials(config_file: str, workflow_config_file: str) -> None
     logger.info(f"Encrypting PIF credentials...")
     config_manager: ConfigManager = ConfigManager(config_file, workflow_config_file)
 
-    key = os.getenv("PIF_SECRET_KEY")
-
-    generate_key_flag = 'yes'
-
-    if not key:
-        print("No existing key found. Generating a new one...")
-        key = Fernet.generate_key()
-    else:
-        print("\nIMPORTANT: If you are using the same environment for multiple (PIF) instances,\n"
-        "generating a new key will make your other instances unable to authenticate with the old key,\n"
-        "and you will have to regenerate credential encryption for those instances.\n")
-
-        generate_key_flag = input(
-            "Enter 'Yes' to generate new key, 'No' to use the existing key: "
-        ).strip().lower()
-
-        if generate_key_flag == "yes":
-            print("Generating a new key...\n")
-            key = Fernet.generate_key()
-        else:
-            key = key.encode()
-
+    key, regenerated = aimoa_fernet_key("PIF_SECRET_KEY", "PIF")
     fernet = Fernet(key)
 
     username = input("Enter PIF DB username: ").strip()
@@ -222,12 +180,43 @@ def encrypt_pif_credentials(config_file: str, workflow_config_file: str) -> None
 
     config_manager.save_config()
 
-    if generate_key_flag == "yes":
+    if regenerated:
         print("\n=== IMPORTANT ===")
         print("For AIMOA-PIF to work properly, please store this key securely as an environment variable using the following:\n")
         print(f'export PIF_SECRET_KEY="{key.decode()}"')
         print(f'Run ../install/export-pif-key.sh to persist this environment variable.')
         print("\n=== END ===")
+
+def aimoa_fernet_key(env_var: str, system_label: str) -> tuple[bytes, bool]:
+    """
+    Returns (key_bytes, regenerated_flag).
+    regenerated_flag is True only if a new key was generated.
+    """
+    key_str = os.getenv(env_var)
+    regenerated = False
+
+    if not key_str:
+        print("No existing key found. Generating a new one...")
+        key = Fernet.generate_key()
+        regenerated = True
+    else:
+        print(
+            f"\nIMPORTANT: If you are using the same environment for multiple ({system_label}) instances,\n"
+            "generating a new key will make your other instances unable to authenticate with the old key,\n"
+            "and you will have to regenerate credential encryption for those instances.\n"
+        )
+        answer = input(
+            "Enter 'Yes' to generate new key, 'No' to use the existing key: "
+        ).strip().lower()
+
+        if answer == "yes":
+            print("Generating a new key...\n")
+            key = Fernet.generate_key()
+            regenerated = True
+        else:
+            key = key_str.encode()
+
+    return key, regenerated
 
 def prompt_with_confirmation(prompt_text):
     """

--- a/src/main.py
+++ b/src/main.py
@@ -93,12 +93,38 @@ def encrypt_emr_credentials(config_file: str, workflow_config_file: str) -> None
     """
     logger.info(f"Encrypting EMR credentials...")
     config_manager: ConfigManager = ConfigManager(config_file, workflow_config_file)
-    key = Fernet.generate_key()
+
+    key = os.getenv("EMR_SECRET_KEY")
+
+    generate_key_flag = 'yes'
+
+    if not key:
+        print("No existing key found. Generating a new one...")
+        key = Fernet.generate_key()
+    else:
+        print("\nIMPORTANT: If you are using the same environment for multiple (document tagging) instances,\n"
+        "generating a new key will make your other instances unable to authenticate with the old key,\n"
+        "and you will have to regenerate credential encryption for those instances.\n")
+
+        generate_key_flag = input(
+            "Enter 'Yes' to generate new key, 'No' to use the existing key: "
+        ).strip().lower()
+
+        if generate_key_flag == "yes":
+            print("Generating a new key...\n")
+            key = Fernet.generate_key()
+        else:
+            key = key.encode()
+
     fernet = Fernet(key)
 
     username = input("Enter EMR username: ").strip()
-    password = getpass.getpass("Enter EMR password: ").strip()
-    pin = getpass.getpass("Enter EMR PIN, press Enter if not needed: ").strip()
+    password = prompt_with_confirmation("Enter EMR password:")
+
+    use_pin = input("Does your EMR uses PIN at login? (y/n): ").strip().lower()
+    pin = None
+    if use_pin in ("y", "yes"):
+        pin = prompt_with_confirmation("Enter EMR PIN: ")
 
     if not username or not password:
         print("Username and Password fields are required.")
@@ -108,16 +134,17 @@ def encrypt_emr_credentials(config_file: str, workflow_config_file: str) -> None
     config_manager.config["emr"]["username"] = fernet.encrypt(username.encode()).decode()
     config_manager.config["emr"]["password"] = fernet.encrypt(password.encode()).decode()
 
-    if pin:
+    if pin and use_pin in ("y", "yes"):
         config_manager.config["emr"]["pin"] = fernet.encrypt(pin.encode()).decode()
 
     config_manager.save_config()
 
-    print("\n=== IMPORTANT ===")
-    print("For AIMOA to work properly, please store this key securely as an environment variable using the following:\n")
-    print(f'export EMR_SECRET_KEY="{key.decode()}"')
-    print(f'Run ../install/export-emr-key.sh to persist this environment variable.')
-    print("\n=== END ===")
+    if generate_key_flag == "yes":
+        print("\n=== IMPORTANT ===")
+        print("For AIMOA to work properly, please store this key securely as an environment variable using the following:\n")
+        print(f'export EMR_SECRET_KEY="{key.decode()}"')
+        print(f'Run ../install/export-emr-key.sh to persist this environment variable.')
+        print("\n=== END ===")
 
 def encrypt_pif_credentials(config_file: str, workflow_config_file: str) -> None:
     """
@@ -151,11 +178,33 @@ def encrypt_pif_credentials(config_file: str, workflow_config_file: str) -> None
     """
     logger.info(f"Encrypting PIF credentials...")
     config_manager: ConfigManager = ConfigManager(config_file, workflow_config_file)
-    key = Fernet.generate_key()
+
+    key = os.getenv("PIF_SECRET_KEY")
+
+    generate_key_flag = 'yes'
+
+    if not key:
+        print("No existing key found. Generating a new one...")
+        key = Fernet.generate_key()
+    else:
+        print("\nIMPORTANT: If you are using the same environment for multiple (PIF) instances,\n"
+        "generating a new key will make your other instances unable to authenticate with the old key,\n"
+        "and you will have to regenerate credential encryption for those instances.\n")
+
+        generate_key_flag = input(
+            "Enter 'Yes' to generate new key, 'No' to use the existing key: "
+        ).strip().lower()
+
+        if generate_key_flag == "yes":
+            print("Generating a new key...\n")
+            key = Fernet.generate_key()
+        else:
+            key = key.encode()
+
     fernet = Fernet(key)
 
     username = input("Enter PIF DB username: ").strip()
-    password = getpass.getpass("Enter PIF DB password: ").strip()
+    password = prompt_with_confirmation("Enter PIF DB password:")
     host = input("Enter PIF Host IP Address: ").strip()
     database = input("Enter PIF Database Name: ").strip()
     table_name = input("Enter PIF Table Name: ").strip()
@@ -173,11 +222,37 @@ def encrypt_pif_credentials(config_file: str, workflow_config_file: str) -> None
 
     config_manager.save_config()
 
-    print("\n=== IMPORTANT ===")
-    print("For AIMOA-PIF to work properly, please store this key securely as an environment variable using the following:\n")
-    print(f'export PIF_SECRET_KEY="{key.decode()}"')
-    print(f'Run ../install/export-pif-key.sh to persist this environment variable.')
-    print("\n=== END ===")
+    if generate_key_flag == "yes":
+        print("\n=== IMPORTANT ===")
+        print("For AIMOA-PIF to work properly, please store this key securely as an environment variable using the following:\n")
+        print(f'export PIF_SECRET_KEY="{key.decode()}"')
+        print(f'Run ../install/export-pif-key.sh to persist this environment variable.')
+        print("\n=== END ===")
+
+def prompt_with_confirmation(prompt_text):
+    """
+    Prompt the user to securely enter a value (e.g., password or PIN) twice
+    using hidden input. The function ensures both entries match and are not empty.
+
+    If the values do not match or are empty, the user is prompted again
+    until valid input is provided.
+
+    Args:
+        prompt_text (str): The message displayed to the user when asking for input.
+
+    Returns:
+        str: The confirmed, non-empty user input.
+    """
+    while True:
+        first = getpass.getpass(prompt_text).strip()
+        second = getpass.getpass("Confirm " + prompt_text).strip()
+
+        if first != second:
+            print("Entries do not match. Please try again.\n")
+        elif not first:
+            print("Value cannot be empty. Please try again.\n")
+        else:
+            return first
 
 class AIMOAAutomation:
     """

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -178,7 +178,7 @@ def get_inbox_pendingdocs_documents(self):
 						self.file_name = item
 					else:
 						self.config.update_pending_inbox(item)
-						self.logger.info(f"Max retries exceeded for processing. Skipping document No: {item[:self.logger_mask_filename_length]}*****.")
+						self.logger.info(f"Max retries exceeded for processing. Skipping document No: {str(item)[:self.logger_mask_filename_length]}*****.")
 					return False
 				else:
 					self.config.update_pending_retries(current_retries + 1)  # Increment the retry count by 1
@@ -192,7 +192,7 @@ def get_inbox_pendingdocs_documents(self):
 
 					if file_response.status_code == 200 and file_response.content:
 						self.config.set_shared_state('current_file', file_response.content)
-						self.logger.info(f"Fetched EMR document from Pending Docs...Processing Document No: {item[:self.logger_mask_filename_length]}*****.")
+						self.logger.info(f"Fetched EMR document from Pending Docs...Processing Document No: {str(item)[:self.logger_mask_filename_length]}*****.")
 						return True
 					else:
 						self.logger.error(f"An error occurred: {file_response.status_code}")
@@ -263,7 +263,7 @@ def get_inbox_incomingdocs_documents(self):
 						else:
 							current_file_plus_one_second = current_file + timedelta(seconds=1)
 							self.config.update_incoming_inbox(str(current_file_plus_one_second))
-							self.logger.info(f"Max retries exceeded for processing. Skipping document No: {item[:self.logger_mask_filename_length]}*****.")
+							self.logger.info(f"Max retries exceeded for processing. Skipping document No: {str(item)[:self.logger_mask_filename_length]}*****.")
 						return False
 					else:
 						self.config.update_incoming_retries(current_retries + 1)  # Increment the retry count by 1
@@ -279,7 +279,7 @@ def get_inbox_incomingdocs_documents(self):
 							self.file_name = option.get_attribute('value')
 							self.inbox_incoming_lastfile = update_time
 							self.config.set_shared_state('current_file', file_response.content)
-							self.logger.info(f"Fetched EMR document from Incoming Docs...Processing Document No: {item[:self.logger_mask_filename_length]}*****.")
+							self.logger.info(f"Fetched EMR document from Incoming Docs...Processing Document No: {str(item)[:self.logger_mask_filename_length]}*****.")
 							return True
 						else:
 							self.logger.error(f"An error occurred: {file_response.status_code}")
@@ -332,7 +332,7 @@ def get_inbox_pendingdocs_documents_opro(self):
 				if value != '-1':
 					self.config.update_pending_retries(0)
 					self.config.update_pending_inbox(item)
-					self.logger.info(f"Document {item[:self.logger_mask_filename_length]}***** already tagged to patient.")
+					self.logger.info(f"Document {str(item)[:self.logger_mask_filename_length]}***** already tagged to patient.")
 					return False
 		else:
 			self.logger.info(f"Unexpected error from server, error code {document_details.status_code}")
@@ -345,15 +345,15 @@ def get_inbox_pendingdocs_documents_opro(self):
 				self.file_name = item
 			else:
 				self.config.update_pending_inbox(item)
-				self.logger.info(f"Max retries exceeded for processing. Skipping document No: {item[:self.logger_mask_filename_length]}*****.")
+				self.logger.info(f"Max retries exceeded for processing. Skipping document No: {str(item)[:self.logger_mask_filename_length]}*****.")
 				return False
 		else:
 			self.config.update_pending_retries(current_retries + 1)
 			self.config.set_shared_state('current_file', file_response.content)
 			self.file_name = item
-			self.logger.info(f"Fetched EMR document from Pending Docs...Processing Document No: {item[:self.logger_mask_filename_length]}*****.")
+			self.logger.info(f"Fetched EMR document from Pending Docs...Processing Document No: {str(item)[:self.logger_mask_filename_length]}*****.")
 			return True
 	else:
-		self.logger.info(f"No more documents to process or error while fetching document {item[:self.logger_mask_filename_length]}*****.")
+		self.logger.info(f"No more documents to process or error while fetching document {str(item)[:self.logger_mask_filename_length]}*****.")
 	return False
 

--- a/src/processors/o19/o19_inbox.py
+++ b/src/processors/o19/o19_inbox.py
@@ -40,7 +40,7 @@ def get_document_processor_type(self):
         >>> print(processor_type)
         True
     """
-	system_type = self.config.get('aimoa_document_processor.type')
+	system_type = self.config.get('aimoa_document_processor.type','emr')
 
 	return system_type in ['emr']
 

--- a/src/processors/o19/o19_updater.py
+++ b/src/processors/o19/o19_updater.py
@@ -145,7 +145,7 @@ def update_o19_pendingdocs(self):
 	response = self.session.post(url, data=params, verify=self.config.get('emr.verify-HTTPS', True), timeout=self.config.get('general_setting.timeout', 300))
 
 	if response.status_code == 200:
-		self.logger.info(f"Completed processing document and posted responses to EMR demographic ({self.demographic_number}) for Document No: {self.file_name[:self.logger_mask_filename_length]}*****")
+		self.logger.info(f"Completed processing document and posted responses to EMR demographic ({self.demographic_number}) for Document No: {str(self.file_name)[:self.logger_mask_filename_length]}*****")
 		return self.update_o19_last_processed_file(self)
 
 	self.logger.error(f"An error occurred: {response.status_code}")
@@ -214,7 +214,7 @@ def update_o19_incomingdocs(self):
 	response = self.session.post(url, data=params, verify=self.config.get('emr.verify-HTTPS', True), timeout=self.config.get('general_setting.timeout', 300))
 
 	if response.status_code == 200:
-		self.logger.info(f"Completed processing document and posted responses to EMR demographic ({self.demographic_number}) for Document No: {self.file_name[:self.logger_mask_filename_length]}*****")
+		self.logger.info(f"Completed processing document and posted responses to EMR demographic ({self.demographic_number}) for Document No: {str(self.file_name)[:self.logger_mask_filename_length]}*****")
 		return self.update_o19_last_processed_file(self)
 		
 	self.logger.error(f"An error occurred: {response.status_code}")

--- a/src/processors/utils/llm.py
+++ b/src/processors/utils/llm.py
@@ -75,12 +75,12 @@ def query_prompt(self,prompt):
     except Timeout:
         self.config.update_lock_status(False)
         self.logger.info(f"Lock released.")
-        self.logger.info(f"An error occurred waiting for LLM response, exceeded time out. Stopping task processing Document No. {self.file_name[:self.logger_mask_filename_length]}*****")
+        self.logger.info(f"An error occurred waiting for LLM response, exceeded time out. Stopping task processing Document No. {str(self.file_name)[:self.logger_mask_filename_length]}*****")
         raise SystemExit("Stopping task due to LLM timed out.")
     except RequestException as e:
         self.config.update_lock_status(False)
         self.logger.info(f"Lock released.")
-        self.logger.info(f"An error occurred waiting for LLM response, LLM Request Exception. Stopping task processing Document No. {self.file_name[:self.logger_mask_filename_length]}*****")
+        self.logger.info(f"An error occurred waiting for LLM response, LLM Request Exception. Stopping task processing Document No. {str(self.file_name)[:self.logger_mask_filename_length]}*****")
         raise SystemExit("Stopping task due to LLM Request Exception.")
     else:
         if response.status_code != 200:

--- a/src/processors/utils/ocr.py
+++ b/src/processors/utils/ocr.py
@@ -241,7 +241,7 @@ def extract_text_doctr_api(self):
         self.logger.debug("Calling OCR API.")
 
         headers = {"accept": "application/json"}
-        params = {"reco_arch": self.config.get('ocr.reco_arch','vitstr_base'), "det_arch": self.config.get('ocr.det_arch','db_resnet50')}
+        params = {"reco_arch": self.config.get('ocr.reco_arch','crnn_vgg16_bn'), "det_arch": self.config.get('ocr.det_arch','fast_base')}
 
         files = [  # application/pdf, image/jpeg, image/png supported
                 ("files", ('ocr_doc.pdf', trimmed_file.getvalue(), "application/pdf")),

--- a/src/processors/workflow/emr_workflow.py
+++ b/src/processors/workflow/emr_workflow.py
@@ -100,7 +100,7 @@ class Workflow:
 
         self.headers['Origin'] = self.origin_url
         self.headers['Referer'] = self.base_url
-        self.headers['User-Agent'] = config.get('emr.user_agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36').replace('\n', '')
+        self.headers['User-Agent'] = config.get('emr.user_agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.101 Safari/537.36').replace('\n', '')
 
         self.update_o19 = o19_updater.update_o19
         self.view_output = o19_updater.view_output


### PR DESCRIPTION
Option to change encryption key or maintain; Default document processor as emr

## Summary by Sourcery

Allow reusing or regenerating encryption keys for EMR and PIF credentials and set EMR as the default document processor type.

Enhancements:
- Support using existing EMR and PIF encryption keys from environment variables with an option to generate new keys when needed.
- Add secure, double-entry prompts for passwords and optional EMR PINs to reduce input errors.
- Default the document processor type configuration to EMR when not explicitly set.